### PR TITLE
[mellanox] enable watchdog before fast-reboot

### DIFF
--- a/scripts/watchdog
+++ b/scripts/watchdog
@@ -63,7 +63,9 @@ function disable_watchdog()
         fi
     elif isMLNX; then
         debug "Calling MLNX WD disable"
-        # call watchdog api for mlnx
+        if [[ -x /usr/bin/hw-management-wd.sh  ]]; then
+            /usr/bin/hw-management-wd.sh stop
+        fi
     else
         if isArista; then
             debug "Calling Arista WD disable"
@@ -84,7 +86,9 @@ function enable_watchdog()
         fi
     elif isMLNX; then
         debug "Calling MLNX WD enable"
-        # call watchdog api for mlnx
+        if [[ -x /usr/bin/hw-management-wd.sh  ]]; then
+            /usr/bin/hw-management-wd.sh start
+        fi
     else
         if isArista; then
             debug "Calling Arista WD enable"


### PR DESCRIPTION
On newer CPLDs this script will enabled hardware watchdog and set timeout
to 600 sec. On older CPLDs this script will fail saying it does not
support mellanox watchdog type 1, however fast-reboot won't fail as by
the time this script is called all services are down, so better to do
fast reboot any way as it was before rathen then failing the whole fast
reboot process and leaving system in failed state.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

