### PR TITLE
[generate_dump] allow to extend dump with plugin scripts.

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -32,6 +32,8 @@ TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
 NUM_ASICS=1
 
+PLUGIN_SCRIPTS="$(find /usr/bin/debug-dump -type f)"
+
 ###############################################################################
 # Runs a comamnd and saves its output to the incrementally built tar.
 # Globals:
@@ -721,6 +723,10 @@ main() {
 
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
+
+    for plugin_script in $PLUGIN_SCRIPTS; do
+	save_cmd "bash $plugin_script" "$(basename $plugin_script)" true
+    done
 
     save_saidump
 


### PR DESCRIPTION
Plugins scripts are placed at /usr/bin/debug-dump/ and
the output of these scripts will be gzipped and placed
under dump archive in dump/<script-name>.gz

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

