### PR TITLE
[sonic_installer] dont fail package migration

### DIFF
--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -31,13 +31,13 @@ def run_command(command):
         sys.exit(proc.returncode)
 
 # Run bash command and return output, raise if it fails
-def run_command_or_raise(argv):
+def run_command_or_raise(argv, raise_exception=True):
     click.echo(click.style("Command: ", fg='cyan') + click.style(' '.join(argv), fg='green'))
 
     proc = subprocess.Popen(argv, text=True, stdout=subprocess.PIPE)
     out, _ = proc.communicate()
 
-    if proc.returncode != 0:
+    if proc.returncode != 0 and raise_exception:
         raise SonicRuntimeException("Failed to run command '{0}'".format(argv))
 
     return out.rstrip("\n")


### PR DESCRIPTION
To not fail when user is doing downgrade

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Do not fail when user is doing downgrade.

#### How I did it
Ignoring failures.

#### How to verify it
On master image install 202012 image.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

