### PR TITLE
[db_migrator] fix old 1911 feature config migration to a new one.

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -174,6 +174,22 @@ class DBMigrator():
         for copp_key in keys:
             self.appDB.delete(self.appDB.APPL_DB, copp_key)
 
+    def migrate_feature_table(self):
+        '''
+        Combine CONTAINER_FEATURE and FEATURE tables into FEATURE table.
+        '''
+
+        feature_table = self.configDB.get_table('FEATURE')
+        for feature, config in feature_table.items():
+            state = config.pop('status', 'disabled')
+            config['state'] = state
+            self.configDB.set_entry('FEATURE', feature, config)
+
+        container_feature_table = self.configDB.get_table('CONTAINER_FEATURE')
+        for feature, config in container_feature_table.items():
+            self.configDB.mod_entry('FEATURE', feature, config)
+            self.configDB.set_entry('CONTAINER_FEATURE', feature, None)
+
     def migrate_config_db_buffer_tables_for_dynamic_calculation(self, speed_list, cable_len_list, default_dynamic_th, abandon_method, append_item_method):
         '''
         Migrate buffer tables to dynamic calculation mode
@@ -419,6 +435,8 @@ class DBMigrator():
         """
         log.log_info('Handling version_1_0_3')
 
+        self.migrate_feature_table()
+
         # Check ASIC type, if Mellanox platform then need DB migration
         if self.asic_type == "mellanox":
             if self.mellanox_buffer_migrator.mlnx_migrate_buffer_pool_size('version_1_0_3', 'version_1_0_4') \
@@ -503,14 +521,12 @@ class DBMigrator():
 
         return 'version_unknown'
 
-
     def set_version(self, version=None):
         if not version:
             version = self.CURRENT_VERSION
         log.log_info('Setting version to ' + version)
         entry = { self.TABLE_FIELD : version }
         self.configDB.set_entry(self.TABLE_NAME, self.TABLE_KEY, entry)
-
 
     def common_migration_ops(self):
         try:
@@ -520,14 +536,16 @@ class DBMigrator():
             raise Exception(str(e))
 
         for init_cfg_table, table_val in init_db.items():
-            data = self.configDB.get_table(init_cfg_table)
-            if data:
-                # Ignore overriding the values that pre-exist in configDB
-                continue
             log.log_info("Migrating table {} from INIT_CFG to config_db".format(init_cfg_table))
-            # Update all tables that do not exist in configDB but are present in INIT_CFG
-            for init_table_key, init_table_val in table_val.items():
-                self.configDB.set_entry(init_cfg_table, init_table_key, init_table_val)
+            for key in table_val:
+                curr_cfg = self.configDB.get_entry(init_cfg_table, key)
+                init_cfg = table_val[key]
+
+                # Override init config with current config.
+                # This will leave new fields from init_config
+                # in new_config, but not override existing configuration.
+                new_cfg = {**init_cfg, **curr_cfg}
+                self.configDB.set_entry(init_cfg_table, key, new_cfg)
 
         self.migrate_copp_table()
 

--- a/tests/db_migrator_input/config_db/feature-expected.json
+++ b/tests/db_migrator_input/config_db/feature-expected.json
@@ -1,0 +1,18 @@
+{
+	"FEATURE|swss": {
+		"auto_restart": "disabled",
+		"has_global_scope": "False",
+		"has_per_asic_scope": "True",
+		"has_timer": "False",
+		"high_mem_alert": "disabled",
+		"state": "enabled"
+	},
+	"FEATURE|telemetry": {
+		"auto_restart": "enabled",
+		"has_global_scope": "False",
+		"has_per_asic_scope": "True",
+		"has_timer": "False",
+		"high_mem_alert": "disabled",
+		"state": "enabled"
+	}
+}

--- a/tests/db_migrator_input/config_db/feature-input.json
+++ b/tests/db_migrator_input/config_db/feature-input.json
@@ -1,0 +1,13 @@
+{
+	"CONTAINER_FEATURE|swss": {
+		"auto_restart": "disabled",
+		"high_mem_alert": "disabled"
+	},
+	"CONTAINER_FEATURE|telemetry": {
+		"auto_restart": "enabled",
+		"high_mem_alert": "disabled"
+	},
+	"FEATURE|telemetry": {
+		"status": "enabled"
+	}
+}

--- a/tests/db_migrator_input/init_cfg.json
+++ b/tests/db_migrator_input/init_cfg.json
@@ -1,2 +1,20 @@
 {
+	"FEATURE": {
+		"swss": {
+			"auto_restart": "enabled",
+			"has_global_scope": "False",
+			"has_per_asic_scope": "True",
+			"has_timer": "False",
+			"high_mem_alert": "disabled",
+			"state": "enabled"
+		},
+		"telemetry": {
+			"auto_restart": "disabled",
+			"has_global_scope": "False",
+			"has_per_asic_scope": "True",
+			"has_timer": "False",
+			"high_mem_alert": "disabled",
+			"state": "disabled"
+		}
+	}
 }

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -2,6 +2,8 @@ import os
 import pytest
 import sys
 
+from deepdiff import DeepDiff
+
 from swsssdk import SonicV2Connector
 from sonic_py_common import device_info
 
@@ -215,3 +217,30 @@ class TestAutoNegMigrator(object):
 
         assert dbmgtr.configDB.get_table('PORT') == expected_db.cfgdb.get_table('PORT')
         assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')
+
+
+class TestInitConfigMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def test_init_config_feature_migration(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'feature-input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'feature-expected')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('FEATURE')
+        expected_table = expected_db.cfgdb.get_table('FEATURE')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff
+
+        assert not expected_db.cfgdb.get_table('CONTAINER_FEATURE')


### PR DESCRIPTION
This change is in addition to https://github.com/Azure/sonic-utilities/pull/1522.
The init_cfg.json may have important fields added to configuration, while in
previous fix these entries will not be added when table already exists.
This change fixes this behaviour. Also, in order to preserve users auto_restart
configuration a special logic for migrating CONTAINER_FEATURE table has been implemented.
A test to cover this scenario is added.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

