### PR TITLE
[db_migrator] fix syntax error due to usage of python >=3.5 feature

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -286,7 +286,8 @@ class DBMigrator():
                 # Override init config with current config.
                 # This will leave new fields from init_config
                 # in new_config, but not override existing configuration.
-                new_cfg = {**init_cfg, **curr_cfg}
+                new_cfg = init_cfg.copy()
+                new_cfg.update(curr_cfg)
                 self.configDB.set_entry(init_cfg_table, key, new_cfg)
 
     def migrate(self):


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

