### PR TITLE
switch from poetry-semver to semantic_version due to bugs found in po…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
         'netaddr>=0.8.0',
         'netifaces>=0.10.7',
         'pexpect>=4.8.0',
-        'poetry-semver>=0.1.0',
+        'semantic-version>=2.8.5',
         'prettyprinter>=0.18.0',
         'pyroute2>=0.5.14, <0.6.1',
         'requests>=2.25.0',

--- a/sonic_package_manager/constraint.py
+++ b/sonic_package_manager/constraint.py
@@ -11,8 +11,15 @@ import semantic_version
 from sonic_package_manager.version import Version
 
 
-class VersionConstraint(semantic_version.SimpleSpec):
-    """ Extends SimpleSpec from semantic_version package. """
+class VersionConstraint:
+    """ Version constraint representation. """
+
+    def __init__(self, *args, **kwargs):
+        self._constraint = semantic_version.SimpleSpec(*args, **kwargs)
+
+    @property
+    def expression(self):
+        return self._constraint.expression
 
     @classmethod
     def parse(cls, constraint_expression: str) -> 'VersionConstraint':
@@ -35,18 +42,7 @@ class VersionConstraint(semantic_version.SimpleSpec):
             Boolean wether this constraint allows version.
         """
 
-        return self.match(version)
-
-    def allows_all(self, other: 'VersionConstraint') -> bool:
-        """ Checks that a version range other overlaps with this range.
-
-        Args:
-            other: VersionConstraint object to check.
-        Returns:
-            Boolean whether this constraint is a superset of other constraint.
-        """
-
-        return other in self
+        return self._constraint.match(version._version)
 
     def is_exact(self) -> bool:
         """ Is the version constraint exact, meaning only one version is allowed.
@@ -55,7 +51,8 @@ class VersionConstraint(semantic_version.SimpleSpec):
             Boolean wether this constraint is exact.
         """
 
-        return hasattr(self.clause, 'target') and self.clause.operator == '=='
+        clause = self._constraint.clause
+        return hasattr(clause, 'target') and clause.operator == '=='
 
     def get_exact_version(self) -> Version:
         """ Returns an exact version for this constraint if it is exact constraint.
@@ -66,7 +63,16 @@ class VersionConstraint(semantic_version.SimpleSpec):
             AttributeError: when constraint is not exact
         """
 
-        return self.clause.target
+        return self._constraint.clause.target
+
+    def __str__(self):
+        return self._constraint.__str__()
+
+    def __repr__(self):
+        return self._constraint.__repr__()
+
+    def __eq__(self, other):
+        return self._constraint.__eq__(other._constraint)
 
 
 @dataclass

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -156,7 +156,7 @@ def validate_package_base_os_constraints(package: Package, sonic_version_info: D
 
         version = Version.parse(sonic_version_info[component])
 
-        if not constraint.allows_all(version):
+        if not constraint.allows(version):
             raise PackageSonicRequirementError(package.name, component, constraint, version)
 
 
@@ -178,7 +178,7 @@ def validate_package_tree(packages: Dict[str, Package]):
 
             installed_version = dependency_package.version
             log.debug(f'dependency package is installed {dependency.name}: {installed_version}')
-            if not dependency.constraint.allows_all(installed_version):
+            if not dependency.constraint.allows(installed_version):
                 raise PackageDependencyError(package.name, dependency, installed_version)
 
             dependency_components = dependency.components
@@ -197,7 +197,7 @@ def validate_package_tree(packages: Dict[str, Package]):
                 log.debug(f'dependency package {dependency.name}: '
                           f'component {component} version is {component_version}')
 
-                if not constraint.allows_all(component_version):
+                if not constraint.allows(component_version):
                     raise PackageComponentDependencyError(package.name, dependency, component,
                                                           constraint, component_version)
 
@@ -209,7 +209,7 @@ def validate_package_tree(packages: Dict[str, Package]):
 
             installed_version = conflicting_package.version
             log.debug(f'conflicting package is installed {conflict.name}: {installed_version}')
-            if conflict.constraint.allows_all(installed_version):
+            if conflict.constraint.allows(installed_version):
                 raise PackageConflictError(package.name, conflict, installed_version)
 
             for component, constraint in conflicting_package.components.items():
@@ -220,7 +220,7 @@ def validate_package_tree(packages: Dict[str, Package]):
                 log.debug(f'conflicting package {dependency.name}: '
                           f'component {component} version is {component_version}')
 
-                if constraint.allows_all(component_version):
+                if constraint.allows(component_version):
                     raise PackageComponentConflictError(package.name, dependency, component,
                                                         constraint, component_version)
 

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -55,7 +55,6 @@ from sonic_package_manager.source import (
 from sonic_package_manager.utils import DockerReference
 from sonic_package_manager.version import (
     Version,
-    VersionRange,
     version_to_tag,
     tag_to_version
 )
@@ -122,13 +121,14 @@ def package_constraint_to_reference(constraint: PackageConstraint) -> PackageRef
     # Allow only specific version for now.
     # Later we can improve package manager to support
     # installing packages using expressions like 'package>1.0.0'
-    if version_constraint == VersionRange():  # empty range means any version
+    if version_constraint.expression == '*':  # empty range means any version
         return PackageReference(package_name, None)
-    if not isinstance(version_constraint, Version):
+    if not version_constraint.is_exact():
         raise PackageManagerError(f'Can only install specific version. '
                                   f'Use only following expression "{package_name}=<version>" '
                                   f'to install specific version')
-    return PackageReference(package_name, version_to_tag(version_constraint))
+    version = version_constraint.get_exact_version()
+    return PackageReference(package_name, version_to_tag(version))
 
 
 def parse_reference_expression(expression):

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -121,7 +121,7 @@ def package_constraint_to_reference(constraint: PackageConstraint) -> PackageRef
     # Allow only specific version for now.
     # Later we can improve package manager to support
     # installing packages using expressions like 'package>1.0.0'
-    if version_constraint.expression == '*':  # empty range means any version
+    if version_constraint.expression == '*':
         return PackageReference(package_name, None)
     if not version_constraint.is_exact():
         raise PackageManagerError(f'Can only install specific version. '

--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -147,7 +147,7 @@ class ManifestSchema:
 
     # TODO: add description for each field
     SCHEMA = ManifestRoot('root', [
-        ManifestField('version', ParsedMarshaller(Version), Version(1, 0, 0)),
+        ManifestField('version', ParsedMarshaller(Version), Version.parse('1.0.0')),
         ManifestRoot('package', [
             ManifestField('version', ParsedMarshaller(Version)),
             ManifestField('name', DefaultMarshaller(str)),

--- a/sonic_package_manager/version.py
+++ b/sonic_package_manager/version.py
@@ -2,10 +2,25 @@
 
 """ Version and helpers routines. """
 
-import semver
+import semantic_version
 
-Version = semver.Version
-VersionRange = semver.VersionRange
+
+class Version(semantic_version.Version):
+    """ Extends Version class from semantic_version package. """
+
+    @classmethod
+    def parse(cls, version_string: str) -> 'Version':
+        """ Construct Version from version_string.
+
+        Args:
+            version_string: SemVer compatible version string.
+        Returns:
+            Version object.
+        Raises:
+            ValueError: when version_string does not follow SemVer.
+        """
+
+        return semantic_version.Version(version_string)
 
 
 def version_to_tag(ver: Version) -> str:

--- a/sonic_package_manager/version.py
+++ b/sonic_package_manager/version.py
@@ -5,8 +5,8 @@
 import semantic_version
 
 
-class Version(semantic_version.Version):
-    """ Extends Version class from semantic_version package. """
+class Version:
+    """ Version class represents SemVer 2.0 compliant version """
 
     @classmethod
     def parse(cls, version_string: str) -> 'Version':
@@ -21,6 +21,51 @@ class Version(semantic_version.Version):
         """
 
         return cls(version_string)
+
+    def __init__(self, *args, **kwargs):
+        self._version = semantic_version.Version(*args, **kwargs)
+
+    @property
+    def major(self):
+        return self._version.major
+
+    @property
+    def minor(self):
+        return self._version.minor
+
+    @property
+    def patch(self):
+        return self._version.patch
+
+    def __str__(self):
+        return self._version.__str__()
+
+    def __repr__(self):
+        return self._version.__repr__()
+
+    def __iter__(self):
+        return self._version.__iter__()
+
+    def __cmp__(self, other):
+        return self._version.__cmp__(other._version)
+
+    def __eq__(self, other):
+        return self._version.__eq__(other._version)
+
+    def __ne__(self, other):
+        return self._version.__ne__(other._version)
+
+    def __lt__(self, other):
+        return self._version.__lt__(other._version)
+
+    def __le__(self, other):
+        return self._version.__le__(other._version)
+
+    def __gt__(self, other):
+        return self._version.__gt__(other._version)
+
+    def __ge__(self, other):
+        return self._version.__ge__(other._version)
 
 
 def version_to_tag(ver: Version) -> str:

--- a/sonic_package_manager/version.py
+++ b/sonic_package_manager/version.py
@@ -20,7 +20,7 @@ class Version(semantic_version.Version):
             ValueError: when version_string does not follow SemVer.
         """
 
-        return semantic_version.Version(version_string)
+        return cls(version_string)
 
 
 def version_to_tag(ver: Version) -> str:

--- a/tests/sonic_package_manager/test_constraint.py
+++ b/tests/sonic_package_manager/test_constraint.py
@@ -1,8 +1,22 @@
 #!/usr/bin/env python
 
+import pytest
+
 from sonic_package_manager import version
-from sonic_package_manager.constraint import PackageConstraint
-from sonic_package_manager.version import Version, VersionRange
+from sonic_package_manager.constraint import PackageConstraint, VersionConstraint
+from sonic_package_manager.version import Version
+
+
+@pytest.mark.parametrize('invalid_version', ['1.2.3-0123', '1.2', '1.0.0+artiary+version'])
+def test_invalid_version(invalid_version):
+    with pytest.raises(Exception):
+        Version.parse(invalid_version)
+
+
+@pytest.mark.parametrize(('newer', 'older'),
+                         [('0.1.1', '0.1.1-alpha')])
+def test_version_comparison(newer, older):
+    assert Version.parse(newer) > Version.parse(older)
 
 
 def test_constraint():
@@ -28,7 +42,7 @@ def test_constraint_strict():
 
 
 def test_constraint_match():
-    package_constraint = PackageConstraint.parse('swss==1.2*.*')
+    package_constraint = PackageConstraint.parse('swss==1.2.*')
     assert package_constraint.name == 'swss'
     assert not package_constraint.constraint.allows(Version.parse('1.1.1'))
     assert package_constraint.constraint.allows(Version.parse('1.2.0'))
@@ -47,7 +61,7 @@ def test_constraint_multiple():
 def test_constraint_only_name():
     package_constraint = PackageConstraint.parse('swss')
     assert package_constraint.name == 'swss'
-    assert package_constraint.constraint == VersionRange()
+    assert package_constraint.constraint == VersionConstraint('*')
 
 
 def test_constraint_from_dict():

--- a/tests/sonic_package_manager/test_database.py
+++ b/tests/sonic_package_manager/test_database.py
@@ -17,7 +17,7 @@ def test_database_get_package(fake_db):
     assert swss_package.built_in
     assert swss_package.repository == 'docker-orchagent'
     assert swss_package.default_reference == '1.0.0'
-    assert swss_package.version == Version(1, 0, 0)
+    assert swss_package.version == Version.parse('1.0.0')
 
 
 def test_database_get_package_not_builtin(fake_db):
@@ -52,11 +52,11 @@ def test_database_add_package_existing(fake_db):
 def test_database_update_package(fake_db):
     test_package = fake_db.get_package('test-package-2')
     test_package.installed = True
-    test_package.version = Version(1, 2, 3)
+    test_package.version = Version.parse('1.2.3')
     fake_db.update_package(test_package)
     test_package = fake_db.get_package('test-package-2')
     assert test_package.installed
-    assert test_package.version == Version(1, 2, 3)
+    assert test_package.version == Version.parse('1.2.3')
 
 
 def test_database_update_package_non_existing(fake_db):

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import re
 from unittest.mock import Mock, call
 
 import pytest
@@ -26,8 +27,8 @@ def test_installation_dependencies(package_manager, fake_metadata_resolver, mock
     manifest = fake_metadata_resolver.metadata_store['Azure/docker-test']['1.6.0']['manifest']
     manifest['package']['depends'] = ['swss^2.0.0']
     with pytest.raises(PackageInstallationError,
-                       match='Package test-package requires swss>=2.0.0,<3.0.0 '
-                             'but version 1.0.0 is installed'):
+                       match=re.escape('Package test-package requires swss^2.0.0 '
+                                       'but version 1.0.0 is installed')):
         package_manager.install('test-package')
 
 
@@ -80,8 +81,8 @@ def test_installation_components_dependencies_not_satisfied(package_manager, fak
         },
     ]
     with pytest.raises(PackageInstallationError,
-                       match='Package test-package requires libswsscommon >=1.1.0,<2.0.0 '
-                             'in package swss>=1.0.0 but version 1.0.0 is installed'):
+                       match=re.escape('Package test-package requires libswsscommon ^1.1.0 '
+                                       'in package swss>=1.0.0 but version 1.0.0 is installed')):
         package_manager.install('test-package')
 
 
@@ -98,8 +99,8 @@ def test_installation_components_dependencies_implicit(package_manager, fake_met
         },
     ]
     with pytest.raises(PackageInstallationError,
-                       match='Package test-package requires libswsscommon >=2.1.0,<3.0.0 '
-                             'in package swss>=1.0.0 but version 1.0.0 is installed'):
+                       match=re.escape('Package test-package requires libswsscommon ^2.1.0 '
+                                       'in package swss>=1.0.0 but version 1.0.0 is installed')):
         package_manager.install('test-package')
 
 
@@ -125,8 +126,8 @@ def test_installation_breaks(package_manager, fake_metadata_resolver):
     manifest = fake_metadata_resolver.metadata_store['Azure/docker-test']['1.6.0']['manifest']
     manifest['package']['breaks'] = ['swss^1.0.0']
     with pytest.raises(PackageInstallationError,
-                       match='Package test-package conflicts with '
-                             'swss>=1.0.0,<2.0.0 but version 1.0.0 is installed'):
+                       match=re.escape('Package test-package conflicts with '
+                                       'swss^1.0.0 but version 1.0.0 is installed')):
         package_manager.install('test-package')
 
 
@@ -288,7 +289,7 @@ def test_manager_upgrade(package_manager, sonic_fs):
 
     package_manager.install('test-package-6=2.0.0')
     upgraded_package = package_manager.get_installed_package('test-package-6')
-    assert upgraded_package.entry.version == Version(2, 0, 0)
+    assert upgraded_package.entry.version == Version.parse('2.0.0')
     assert upgraded_package.entry.default_reference == package.entry.default_reference
 
 
@@ -298,7 +299,7 @@ def test_manager_package_reset(package_manager, sonic_fs):
 
     package_manager.reset('test-package-6')
     upgraded_package = package_manager.get_installed_package('test-package-6')
-    assert upgraded_package.entry.version == Version(1, 5, 0)
+    assert upgraded_package.entry.version == Version.parse('1.5.0')
 
 
 def test_manager_migration(package_manager, fake_db_for_migration):

--- a/tests/sonic_package_manager/test_manifest.py
+++ b/tests/sonic_package_manager/test_manifest.py
@@ -4,7 +4,6 @@ import pytest
 
 from sonic_package_manager.constraint import ComponentConstraints
 from sonic_package_manager.manifest import Manifest, ManifestError
-from sonic_package_manager.version import VersionRange
 
 
 def test_manifest_v1_defaults():


### PR DESCRIPTION
…etry-semver and lack of maintanance of that package

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

