### PR TITLE
[sonic-package-manager] fix registry requests failing when no "service" field in Authorization header

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ setup(
     ],
     tests_require = [
         'pyfakefs',
+        'responses',
         'pytest',
         'mockredispy>=2.9.3',
         'deepdiff==5.2.3'

--- a/tests/sonic_package_manager/test_registry.py
+++ b/tests/sonic_package_manager/test_registry.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import requests
+import responses
 from sonic_package_manager.registry import RegistryResolver
 
 
@@ -13,3 +15,22 @@ def test_get_registry_for():
     assert registry.url == 'https://registry-server:5000'
     registry = resolver.get_registry_for('registry-server.com/docker')
     assert registry.url == 'https://registry-server.com'
+
+
+@responses.activate
+def test_registry_auth():
+    resolver = RegistryResolver()
+    registry = resolver.get_registry_for('registry-server:5000/docker')
+    responses.add(responses.GET, registry.url + '/v2/docker/tags/list',
+                  headers={
+                      'www-authenticate': 'Bearer realm="https://auth.docker.io/token",scope="repository:library/docker:pull,push"'
+                  },
+                  status=requests.codes.unauthorized)
+    responses.add(responses.GET,
+                  'https://auth.docker.io/token?scope=repository:library/docker:pull,push',
+                  json={'token': 'a', 'expires_in': '100'},
+                  status=requests.codes.ok)
+    responses.add(responses.GET, registry.url + '/v2/docker/tags/list',
+                  json={'tags': ['a', 'b']},
+                  status=requests.codes.ok)
+    assert registry.tags('registry-server:5000/docker') == ['a', 'b']


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

If Auth service did not reply with "service" field, don't fail and request the token without it.

#### How I did it

Modified registry.py and added UT.

#### How to verify it

Tested on DUT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

