### PR TITLE
[202012][aclshow] fix aclshow when clear is called before counters ar…

### DIFF
--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -126,6 +126,8 @@ class AclStat(object):
             """
             for table, rule in self.acl_rules:
                 cnt_props = lowercase_keys(self.db.get_all(self.db.COUNTERS_DB, "COUNTERS:%s:%s" % (table, rule)))
+                if not cnt_props:
+                    continue
                 self.acl_counters[table, rule] = cnt_props
 
             if verboseflag:
@@ -141,7 +143,7 @@ class AclStat(object):
         """
         return the counter value or the difference comparing with the saved value in string format
         """
-        if not self.acl_counters[key]:
+        if key not in self.acl_counters:
             return 'N/A'
 
         if key in self.saved_acl_counters:

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -33,27 +33,28 @@ RULE_6        EVERFLOW        9994              601            600
 
 # Expected output for aclshow -a
 all_output = '' + \
-"""RULE NAME                              TABLE NAME       PRIO  PACKETS COUNT    BYTES COUNT
--------------------------------------  -------------  ------  ---------------  -------------
-RULE_1                                 DATAACL          9999  101              100
-RULE_2                                 DATAACL          9998  201              200
-RULE_3                                 DATAACL          9997  301              300
-RULE_4                                 DATAACL          9996  401              400
-RULE_05                                DATAACL          9995  0                0
-RULE_7                                 DATAACL          9993  701              700
-RULE_9                                 DATAACL          9991  901              900
-RULE_10                                DATAACL          9989  1001             1000
-DEFAULT_RULE                           DATAACL             1  2                1
-RULE_6                                 EVERFLOW         9994  601              600
-RULE_08                                EVERFLOW         9992  0                0
-RULE_1                                 NULL_ROUTE_V4    9999  N/A              N/A
-BLOCK_RULE_10.0.0.2/32                 NULL_ROUTE_V4    9999  N/A              N/A
-BLOCK_RULE_10.0.0.3/32                 NULL_ROUTE_V4    9999  N/A              N/A
-DEFAULT_RULE                           NULL_ROUTE_V4       1  N/A              N/A
-RULE_1                                 NULL_ROUTE_V6    9999  N/A              N/A
-BLOCK_RULE_1000:1000:1000:1000::2/128  NULL_ROUTE_V6    9999  N/A              N/A
-BLOCK_RULE_1000:1000:1000:1000::3/128  NULL_ROUTE_V6    9999  N/A              N/A
-DEFAULT_RULE                           NULL_ROUTE_V6       1  N/A              N/A
+"""RULE NAME                              TABLE NAME            PRIO  PACKETS COUNT    BYTES COUNT
+-------------------------------------  ------------------  ------  ---------------  -------------
+RULE_1                                 DATAACL               9999  101              100
+RULE_2                                 DATAACL               9998  201              200
+RULE_3                                 DATAACL               9997  301              300
+RULE_4                                 DATAACL               9996  401              400
+RULE_05                                DATAACL               9995  0                0
+RULE_7                                 DATAACL               9993  701              700
+RULE_9                                 DATAACL               9991  901              900
+RULE_10                                DATAACL               9989  1001             1000
+DEFAULT_RULE                           DATAACL                  1  2                1
+RULE_NO_COUNTER                        DATAACL_NO_COUNTER    9995  N/A              N/A
+RULE_6                                 EVERFLOW              9994  601              600
+RULE_08                                EVERFLOW              9992  0                0
+RULE_1                                 NULL_ROUTE_V4         9999  N/A              N/A
+BLOCK_RULE_10.0.0.2/32                 NULL_ROUTE_V4         9999  N/A              N/A
+BLOCK_RULE_10.0.0.3/32                 NULL_ROUTE_V4         9999  N/A              N/A
+DEFAULT_RULE                           NULL_ROUTE_V4            1  N/A              N/A
+RULE_1                                 NULL_ROUTE_V6         9999  N/A              N/A
+BLOCK_RULE_1000:1000:1000:1000::2/128  NULL_ROUTE_V6         9999  N/A              N/A
+BLOCK_RULE_1000:1000:1000:1000::3/128  NULL_ROUTE_V6         9999  N/A              N/A
+DEFAULT_RULE                           NULL_ROUTE_V6            1  N/A              N/A
 """
 
 # Expected output for aclshow -r RULE_1 -t DATAACL
@@ -86,8 +87,8 @@ rule0_output = '' + \
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 10
-Total number of ACL Rules: 19
+Total number of ACL Tables: 11
+Total number of ACL Rules: 20
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
@@ -122,27 +123,53 @@ clear_output = ''
 # Expected output for
 # aclshow -a -c ; aclshow -a
 all_after_clear_output = '' + \
-"""RULE NAME                              TABLE NAME       PRIO  PACKETS COUNT    BYTES COUNT
--------------------------------------  -------------  ------  ---------------  -------------
-RULE_1                                 DATAACL          9999  0                0
-RULE_2                                 DATAACL          9998  0                0
-RULE_3                                 DATAACL          9997  0                0
-RULE_4                                 DATAACL          9996  0                0
-RULE_05                                DATAACL          9995  0                0
-RULE_7                                 DATAACL          9993  0                0
-RULE_9                                 DATAACL          9991  0                0
-RULE_10                                DATAACL          9989  0                0
-DEFAULT_RULE                           DATAACL             1  0                0
-RULE_6                                 EVERFLOW         9994  0                0
-RULE_08                                EVERFLOW         9992  0                0
-RULE_1                                 NULL_ROUTE_V4    9999  N/A              N/A
-BLOCK_RULE_10.0.0.2/32                 NULL_ROUTE_V4    9999  N/A              N/A
-BLOCK_RULE_10.0.0.3/32                 NULL_ROUTE_V4    9999  N/A              N/A
-DEFAULT_RULE                           NULL_ROUTE_V4       1  N/A              N/A
-RULE_1                                 NULL_ROUTE_V6    9999  N/A              N/A
-BLOCK_RULE_1000:1000:1000:1000::2/128  NULL_ROUTE_V6    9999  N/A              N/A
-BLOCK_RULE_1000:1000:1000:1000::3/128  NULL_ROUTE_V6    9999  N/A              N/A
-DEFAULT_RULE                           NULL_ROUTE_V6       1  N/A              N/A
+"""RULE NAME                              TABLE NAME            PRIO  PACKETS COUNT    BYTES COUNT
+-------------------------------------  ------------------  ------  ---------------  -------------
+RULE_1                                 DATAACL               9999  0                0
+RULE_2                                 DATAACL               9998  0                0
+RULE_3                                 DATAACL               9997  0                0
+RULE_4                                 DATAACL               9996  0                0
+RULE_05                                DATAACL               9995  0                0
+RULE_7                                 DATAACL               9993  0                0
+RULE_9                                 DATAACL               9991  0                0
+RULE_10                                DATAACL               9989  0                0
+DEFAULT_RULE                           DATAACL                  1  0                0
+RULE_NO_COUNTER                        DATAACL_NO_COUNTER    9995  N/A              N/A
+RULE_6                                 EVERFLOW              9994  0                0
+RULE_08                                EVERFLOW              9992  0                0
+RULE_1                                 NULL_ROUTE_V4         9999  N/A              N/A
+BLOCK_RULE_10.0.0.2/32                 NULL_ROUTE_V4         9999  N/A              N/A
+BLOCK_RULE_10.0.0.3/32                 NULL_ROUTE_V4         9999  N/A              N/A
+DEFAULT_RULE                           NULL_ROUTE_V4            1  N/A              N/A
+RULE_1                                 NULL_ROUTE_V6         9999  N/A              N/A
+BLOCK_RULE_1000:1000:1000:1000::2/128  NULL_ROUTE_V6         9999  N/A              N/A
+BLOCK_RULE_1000:1000:1000:1000::3/128  NULL_ROUTE_V6         9999  N/A              N/A
+DEFAULT_RULE                           NULL_ROUTE_V6            1  N/A              N/A
+"""
+
+all_after_clear_and_populate_output = '' + \
+"""RULE NAME                              TABLE NAME            PRIO  PACKETS COUNT    BYTES COUNT
+-------------------------------------  ------------------  ------  ---------------  -------------
+RULE_1                                 DATAACL               9999  0                0
+RULE_2                                 DATAACL               9998  0                0
+RULE_3                                 DATAACL               9997  0                0
+RULE_4                                 DATAACL               9996  0                0
+RULE_05                                DATAACL               9995  0                0
+RULE_7                                 DATAACL               9993  0                0
+RULE_9                                 DATAACL               9991  0                0
+RULE_10                                DATAACL               9989  0                0
+DEFAULT_RULE                           DATAACL                  1  0                0
+RULE_NO_COUNTER                        DATAACL_NO_COUNTER    9995  100              100
+RULE_6                                 EVERFLOW              9994  0                0
+RULE_08                                EVERFLOW              9992  0                0
+RULE_1                                 NULL_ROUTE_V4         9999  N/A              N/A
+BLOCK_RULE_10.0.0.2/32                 NULL_ROUTE_V4         9999  N/A              N/A
+BLOCK_RULE_10.0.0.3/32                 NULL_ROUTE_V4         9999  N/A              N/A
+DEFAULT_RULE                           NULL_ROUTE_V4            1  N/A              N/A
+RULE_1                                 NULL_ROUTE_V6         9999  N/A              N/A
+BLOCK_RULE_1000:1000:1000:1000::2/128  NULL_ROUTE_V6         9999  N/A              N/A
+BLOCK_RULE_1000:1000:1000:1000::3/128  NULL_ROUTE_V6         9999  N/A              N/A
+DEFAULT_RULE                           NULL_ROUTE_V6            1  N/A              N/A
 """
 
 class Aclshow():
@@ -246,3 +273,20 @@ def test_all_after_clear():
     nullify_on_start, nullify_on_exit = False, True
     test = Aclshow(nullify_on_start, nullify_on_exit, all=True, clear=False, rules=None, tables=None, verbose=None)
     assert test.result.getvalue() == all_after_clear_output
+
+def test_clear_and_populate_counters_db():
+    # No counters yet for DATAACL_NO_COUNTER:RULE_NO_COUNTER
+    nullify_on_start, nullify_on_exit = True, False
+    test = Aclshow(nullify_on_start, nullify_on_exit, all=True, clear=True, rules=None, tables=None, verbose=None)
+    assert test.result.getvalue() == clear_output
+    nullify_on_start, nullify_on_exit = False, True
+
+    # Counters populated.
+    conn = dbconnector.SonicV2Connector()
+    conn.connect(conn.COUNTERS_DB)
+    conn.set(conn.COUNTERS_DB, 'COUNTERS:DATAACL_NO_COUNTER:RULE_NO_COUNTER', 'packets', '100')
+    conn.set(conn.COUNTERS_DB, 'COUNTERS:DATAACL_NO_COUNTER:RULE_NO_COUNTER', 'bytes', '100')
+
+    with mock.patch('swsssdk.SonicV2Connector', return_value=conn):
+        test = Aclshow(nullify_on_start, nullify_on_exit, all=True, clear=False, rules=None, tables=None, verbose=None)
+    assert test.result.getvalue() == all_after_clear_and_populate_output

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -433,6 +433,11 @@
         "priority": "9989",
         "SRC_IP": "10.0.0.3/32"
     },
+    "ACL_RULE|DATAACL_NO_COUNTER|RULE_NO_COUNTER": {
+        "IP_PROTOCOL": "126",
+        "PACKET_ACTION": "FORWARD",
+        "PRIORITY": "9995"
+    },
     "ACL_TABLE|NULL_ROUTE_V4": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023",
@@ -444,6 +449,11 @@
         "type": "L3V6"
     },
     "ACL_TABLE|DATAACL": {
+        "policy_desc": "DATAACL",
+        "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
+        "type": "L3"
+    },
+    "ACL_TABLE|DATAACL_NO_COUNTER": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
         "type": "L3"


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed a bug that in case ACL counters are cleared before counters are populated in COUNTERS DB the next aclshow will fail:

```
admin@sonic:~$ aclshow -c -t DATAACL
admin@sonic:~$ aclshow -a -t DATAACL
'NoneType' object is not subscriptable  
```

#### How I did it

Keep self.acl_counters in sync with COUNTERS DB and don't put empty values when no counters are available, so when dumping counters and loading them back there are no empty values.

#### How to verify it

Without this change the added UT fails:

```
self = <aclshow.AclStat object at 0x7f0208277438>, key = ('DATAACL_NO_COUNTER', 'RULE_NO_COUNTER'), type = 'SAI_ACL_COUNTER_ATTR_PACKETS'
                                                                                     
    def get_counter_value(self, key, type):                                          
        """                                                                          
        return the counter value or the difference comparing with the saved value in string format
        """                                                                          
        if not self.acl_counters[key]:                                               
            return 'N/A'                                                             
                                                                                     
        if key in self.saved_acl_counters: 
>           new_value = int(self.acl_counters[key][type]) - int(self.saved_acl_counters[key][type])
E           TypeError: 'NoneType' object is not subscriptable  
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

