### PR TITLE
[sonic-package-manager] do not mod_config for whole config db when se…

### DIFF
--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -491,12 +491,22 @@ class ServiceCreator:
         if not init_cfg:
             return
 
+        def update_config_with_init_cfg(cfg, conn):
+            for table, content in init_cfg.items():
+                if not isinstance(content, dict):
+                    continue
+
+                for key, fvs in content.items():
+                    key_cfg = cfg.get(table, {}).get(key, {})
+                    key_cfg.update(fvs)
+                    conn.mod_entry(table, key, key_cfg)
+
         for conn in self.sonic_db.get_connectors():
             cfg = conn.get_config()
             new_cfg = init_cfg.copy()
             utils.deep_update(new_cfg, cfg)
             self.validate_config(new_cfg)
-            conn.mod_config(new_cfg)
+            update_config_with_init_cfg(cfg, conn)
 
     def remove_config(self, package):
         """ Remove configuration based on package YANG module.

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -131,7 +131,9 @@ def test_service_creator_yang(sonic_fs, manifest, mock_sonic_db,
     mock_sonic_db.get_connectors = Mock(return_value=[mock_connector])
     mock_connector.get_table = Mock(return_value={'key_a': {'field_1': 'value_1'}})
     mock_connector.get_config = Mock(return_value={
-        'TABLE_A': mock_connector.get_table('')
+        'TABLE_A': mock_connector.get_table(''),
+        'TABLE_B': mock_connector.get_table(''),
+        'TABLE_C': mock_connector.get_table(''),
     })
 
     entry = PackageEntry('test', 'azure/sonic-test')
@@ -155,15 +157,8 @@ def test_service_creator_yang(sonic_fs, manifest, mock_sonic_db,
 
     mock_config_mgmt.add_module.assert_called_with(test_yang)
 
-    mock_connector.mod_config.assert_called_with(
-        {
-            'TABLE_A': {
-                'key_a': {
-                    'field_1': 'value_1',
-                    'field_2': 'value_2',
-                },
-            },
-        }
+    mock_connector.mod_entry.assert_called_once_with(
+        'TABLE_A', 'key_a', {'field_1': 'value_1', 'field_2': 'value_2'}
     )
 
     mock_config_mgmt.sy.confDbYangMap = {


### PR DESCRIPTION
…tting init_cfg

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

```conn.mod_config(new_cfg)``` modifies entries which where not changed in ```new_cfg```.
This causes errors when installing/upgrading extension like, because mod_config pushes the same configuration again: 
```
"ERR swss#orchagent: :- addOperation: Vxlan tunnel 'tunnel1' is already exists” in syslog
```
I made a change so that when setting init configuration for an extension we are not modifying the whole DB.


#### How I did it

Perform a ```conn.mod_entry``` for entries from init configuration of the package.

#### How to verify it

Run UT. Make sure no errors when installing extension and having vxlan configuration in config db.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

