### PR TITLE
[sonic-cli-gen] fix failure "Error: digits_class" when field "digit_c…

### DIFF
--- a/sonic-utilities-data/templates/sonic-cli-gen/config.py.j2
+++ b/sonic-utilities-data/templates/sonic-cli-gen/config.py.j2
@@ -102,7 +102,7 @@ def update_entry_validated(db, table, key, data, create_if_not_exists=False):
 
     entry_changed = False
     for attr, value in data.items():
-        if value == cfg[table][key][attr]:
+        if value == cfg[table][key].get(attr):
             continue
         entry_changed = True
         if value is None:

--- a/tests/cli_autogen_input/autogen_test/show_cmd_output.py
+++ b/tests/cli_autogen_input/autogen_test/show_cmd_output.py
@@ -4,16 +4,16 @@ This module are holding correct output for the show command for cli_autogen_test
 
 
 show_device_metadata_localhost="""\
-HWSKU        DEFAULT BGP STATUS    DOCKER ROUTING CONFIG MODE    HOSTNAME    PLATFORM                MAC                DEFAULT PFCWD STATUS    BGP ASN    DEPLOYMENT ID    TYPE       BUFFER MODEL    FRR MGMT FRAMEWORK CONFIG
------------  --------------------  ----------------------------  ----------  ----------------------  -----------------  ----------------------  ---------  ---------------  ---------  --------------  ---------------------------
-ACS-MSN2100  up                    N/A                           r-sonic-01  x86_64-mlnx_msn2100-r0  ff:ff:ff:ff:ff:00  disable                 N/A        N/A              ToRRouter  traditional     N/A
+HWSKU        DEFAULT BGP STATUS    DOCKER ROUTING CONFIG MODE    HOSTNAME    PLATFORM                MAC                DEFAULT PFCWD STATUS    BGP ASN    DEPLOYMENT ID    NON EXISTING FIELD    TYPE       BUFFER MODEL    FRR MGMT FRAMEWORK CONFIG
+-----------  --------------------  ----------------------------  ----------  ----------------------  -----------------  ----------------------  ---------  ---------------  --------------------  ---------  --------------  ---------------------------
+ACS-MSN2100  up                    N/A                           r-sonic-01  x86_64-mlnx_msn2100-r0  ff:ff:ff:ff:ff:00  disable                 N/A        N/A              N/A                   ToRRouter  traditional     N/A
 """
 
 
 show_device_metadata_localhost_changed_buffer_model="""\
-HWSKU        DEFAULT BGP STATUS    DOCKER ROUTING CONFIG MODE    HOSTNAME    PLATFORM                MAC                DEFAULT PFCWD STATUS    BGP ASN    DEPLOYMENT ID    TYPE       BUFFER MODEL    FRR MGMT FRAMEWORK CONFIG
------------  --------------------  ----------------------------  ----------  ----------------------  -----------------  ----------------------  ---------  ---------------  ---------  --------------  ---------------------------
-ACS-MSN2100  up                    N/A                           r-sonic-01  x86_64-mlnx_msn2100-r0  ff:ff:ff:ff:ff:00  disable                 N/A        N/A              ToRRouter  dynamic         N/A
+HWSKU        DEFAULT BGP STATUS    DOCKER ROUTING CONFIG MODE    HOSTNAME    PLATFORM                MAC                DEFAULT PFCWD STATUS    BGP ASN    DEPLOYMENT ID    NON EXISTING FIELD    TYPE       BUFFER MODEL    FRR MGMT FRAMEWORK CONFIG
+-----------  --------------------  ----------------------------  ----------  ----------------------  -----------------  ----------------------  ---------  ---------------  --------------------  ---------  --------------  ---------------------------
+ACS-MSN2100  up                    N/A                           r-sonic-01  x86_64-mlnx_msn2100-r0  ff:ff:ff:ff:ff:00  disable                 N/A        N/A              N/A                   ToRRouter  dynamic         N/A
 """
 
 

--- a/tests/cli_autogen_input/autogen_test/sonic-device_metadata.yang
+++ b/tests/cli_autogen_input/autogen_test/sonic-device_metadata.yang
@@ -88,6 +88,10 @@ module sonic-device_metadata {
                     type uint32;
                 }
 
+                leaf non_existing_field {
+                    type uint32;
+                }
+
                 leaf type {
                     type string {
                         length 1..255;

--- a/tests/cli_autogen_test.py
+++ b/tests/cli_autogen_test.py
@@ -109,6 +109,18 @@ class TestCliAutogen:
         assert result.exit_code == SUCCESS
         assert result.output == show_cmd_output.show_device_metadata_localhost_changed_buffer_model
 
+    def test_config_device_metadata_non_existing_field(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = mock_db_path
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            config_main.config.commands['device-metadata'].commands['localhost'].commands['non-existing-field'], ['12'], obj=db
+        )
+
+        logger.debug("\n" + result.output)
+        logger.debug(result.exit_code)
+        assert result.exit_code == SUCCESS
 
     @pytest.mark.parametrize("parameter,value", [
         ('default-bgp-status', INVALID_VALUE),


### PR DESCRIPTION
…lass" does not exist in DB

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix an issue when trying to set a field which is not in CONFIG DB using auto generated CLI:

E.g:
```
admin@sonic:~$ sudo config passwh policies digits-class true
 "Error: digits_class"
```

#### How I did it

Use ```.get``` on dict instead of ```[]```.

#### How to verify it

Run UT, run generated CLI and configure a field that does not exist in CONFIG DB.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

