### PR TITLE
[scripts/fast-reboot] Shutdown remaining containers through systemd

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -738,25 +738,12 @@ for service in ${SERVICES_TO_STOP}; do
     fi
 done
 
-# Kill other containers to make the reboot faster
-# We call `docker kill ...` to ensure the container stops as quickly as possible,
-# then immediately call `systemctl stop ...` to prevent the service from
-# restarting the container automatically.
-debug "Stopping all remaining containers ..."
 if test -f /usr/local/bin/ctrmgr_tools.py
 then
+    debug "Stopping all remaining containers ..."
     /usr/local/bin/ctrmgr_tools.py kill-all
-else
-    for CONTAINER_NAME in $(docker ps --format '{{.Names}}'); do
-        CONTAINER_STOP_RC=0
-        docker kill $CONTAINER_NAME &> /dev/null || CONTAINER_STOP_RC=$?
-        systemctl stop $CONTAINER_NAME || debug "Ignore stopping $CONTAINER_NAME error $?"
-        if [[ CONTAINER_STOP_RC -ne 0 ]]; then
-            debug "Failed killing container $CONTAINER_NAME RC $CONTAINER_STOP_RC ."
-        fi
-    done
+    debug "Stopped all remaining containers ..."
 fi
-debug "Stopped all remaining containers ..."
 
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service || debug "Ignore stopping docker service error $?"


### PR DESCRIPTION
The current implementation has two issues:

1. In case containers from "docker ps" output are ordered in a way that
database is first in the list, the "systemctl stop database" followed by
"docker kill database" will stop all other containers through systemd
and ruin this optimization
2. After "docker kill database" there are lots of errors from daemons
like hostcfgd, system-healthd, caclmgrd, etc. Also it causes those
daemons to hang when received SIGTERM making a delay on following
"systemctl stop database".

In the new implementation, services are implicitelly stopped by systemd
in the order that is correct. If a certain container needs an
optimization that will kill the container instead of stopping it the
container may implement this optimization in its /usr/local/bin/*.sh
script.

It is also more optimal since independent services might be stopped in
parallel.

NOTE: This fix is relevant for regular SONiC image and not for
Kubernetes enabled SONiC image. Kubernetes integration in SONiC might
have this issue still, which might be a design flawn.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

