### PR TITLE
[config/show] Add command to control pending FIB suppression

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2001,17 +2001,12 @@ def synchronous_mode(sync_mode):
 # 'suppress-pending-fib' command ('config suppress-pending-fib ...')
 #
 @config.command('suppress-pending-fib')
-@click.argument('state', metavar='<enable|disable>', required=True)
+@click.argument('state', metavar='<enabled|disabled>', required=True, type=click.Choice(['enabled', 'disabled']))
 @clicommon.pass_db
 def suppress_pending_fib(db, state):
     ''' Enable or disable pending FIB suppression. Once enabled, BGP will not advertise routes that are not yet installed in the hardware '''
 
-    if state not in ('enabled', 'disabled'):
-        raise click.BadParameter(f'Error: Invalid argument {state}, expect either enabled or disabled')
-
     config_db = db.cfgdb
-    sync_mode = config_db.get_entry('DEVICE_METADATA', 'localhost').get('synchronous_mode')
-
     config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"suppress-pending-fib" : state})
 
 #

--- a/config/main.py
+++ b/config/main.py
@@ -1792,7 +1792,7 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_pat
                 cfggen_namespace_option = " -n {}".format(namespace)
             clicommon.run_command(db_migrator + ' -o set_version' + cfggen_namespace_option)
 
-    # Keep device isolated with TSA 
+    # Keep device isolated with TSA
     if traffic_shift_away:
         clicommon.run_command("TSA", display_cmd=True)
         if golden_config_path or not golden_config_path and os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
@@ -1998,8 +1998,25 @@ def synchronous_mode(sync_mode):
         raise click.BadParameter("Error: Invalid argument %s, expect either enable or disable" % sync_mode)
 
 #
+# 'suppress-pending-fib' command ('config suppress-pending-fib ...')
+#
+@config.command('suppress-pending-fib')
+@click.argument('state', metavar='<enable|disable>', required=True)
+@clicommon.pass_db
+def suppress_pending_fib(db, state):
+    ''' Enable or disable pending FIB suppression. Once enabled, BGP will not advertise routes that are not yet installed in the hardware '''
+
+    if state not in ('enabled', 'disabled'):
+        raise click.BadParameter(f'Error: Invalid argument {state}, expect either enabled or disabled')
+
+    config_db = db.cfgdb
+    sync_mode = config_db.get_entry('DEVICE_METADATA', 'localhost').get('synchronous_mode')
+
+    config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"suppress-pending-fib" : state})
+
+#
 # 'yang_config_validation' command ('config yang_config_validation ...')
-# 
+#
 @config.command('yang_config_validation')
 @click.argument('yang_config_validation', metavar='<enable|disable>', required=True)
 def yang_config_validation(yang_config_validation):

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2112,7 +2112,7 @@ Once enabled, BGP will not advertise routes which aren't yet offloaded.
   admin@sonic:~$ sudo config suppress-pending-fib enabled
   ```
   ```
-  admin@sonic:~$ sudo config suppress-pending-fib enabled
+  admin@sonic:~$ sudo config suppress-pending-fib disabled 
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#bgp)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1987,6 +1987,25 @@ This command displays the routing policy that takes precedence over the other ro
       Exit routemap
   ```
 
+**show suppress-pending-fib**
+
+This command is used to show the status of suppress pending FIB feature.
+When enabled, BGP will not advertise routes which aren't yet offloaded.
+
+- Usage:
+  ```
+  show suppress-pending-fib
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ show suppress-pending-fib
+  Enabled
+  ```
+  ```
+  admin@sonic:~$ show suppress-pending-fib
+  Disabled
+  ```
 
 ### BGP config commands
 
@@ -2076,6 +2095,24 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
   ```
   ```
   admin@sonic:~$ sudo config bgp remove neighbor SONIC02SPINE
+  ```
+
+**config suppress-pending-fib**
+
+This command is used to enable or disable announcements of routes not yet installed in the HW.
+Once enabled, BGP will not advertise routes which aren't yet offloaded.
+
+- Usage:
+  ```
+  config suppress-pending-fib <enabled|disabled>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config suppress-pending-fib enabled
+  ```
+  ```
+  admin@sonic:~$ sudo config suppress-pending-fib enabled
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#bgp)

--- a/show/main.py
+++ b/show/main.py
@@ -2000,6 +2000,17 @@ def peer(db, peer_ip):
     click.echo(tabulate(bfd_body, bfd_headers))
 
 
+# 'suppress-pending-fib' subcommand ("show suppress-pending-fib")
+@cli.command('suppress-pending-fib')
+@clicommon.pass_db
+def suppress_pending_fib(db):
+    """ Show the status of suppress pending FIB feature """
+
+    field_values = db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')
+    state = field_values.get('suppress-pending-fib', 'disabled').title()
+    click.echo(state)
+
+
 # Load plugins and register them
 helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -1,0 +1,34 @@
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+
+class TestSuppressFibPending:
+    def test_synchronous_mode(self):
+        runner = CliRunner()
+
+        db = Db()
+
+        result = runner.invoke(config.config.commands['suppress-pending-fib'], ['enabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry('DEVICE_METADATA' , 'localhost')['suppress-pending-fib'] == 'enabled'
+
+        result = runner.invoke(show.cli.commands['suppress-pending-fib'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'Enabled\n'
+
+        result = runner.invoke(config.config.commands['suppress-pending-fib'], ['disabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry('DEVICE_METADATA' , 'localhost')['suppress-pending-fib'] == 'disabled'
+
+        result = runner.invoke(show.cli.commands['suppress-pending-fib'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'Disabled\n'
+
+        result = runner.invoke(config.config.commands['suppress-pending-fib'], ['invalid-input'], obj=db)
+        print(result.output)
+        assert result.exit_code != 0


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I added a command *config suppress-pending-fib* that will allow user to enable/disable this feature.
Once it is enabled, BGP will wait for route to be programmed to HW before announcing the route to the peers.

I also added a corresponding *show* command that prints the status of this feature.

#### How I did it

Added a config command, updated Command Reference and added a UT.

#### How to verify it

UT and executing this command on the switch.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

