### PR TITLE
Route check frr suppress

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -72,6 +72,9 @@ MAX_SCAN_INTERVAL = 3600    # An hour
 
 PRINT_MSG_LEN_MAX = 1000
 
+FRR_CHECK_RETRIES = 3
+FRR_WAIT_TIME = 5
+
 class Level(Enum):
     ERR = 'ERR'
     INFO = 'INFO'
@@ -516,7 +519,7 @@ def check_frr_pending_routes():
 
     missed_rt = []
 
-    retries = 3
+    retries = FRR_CHECK_RETRIES
     for i in range(retries):
         missed_rt = []
         frr_routes = get_frr_routes()
@@ -532,7 +535,7 @@ def check_frr_pending_routes():
         if not missed_rt:
             break
 
-        time.sleep(5)
+        time.sleep(FRR_WAIT_TIME)
 
     return missed_rt
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -11,11 +11,11 @@ What it is:
 How:
     NOTE: The flow from APPL-DB to ASIC-DB takes non zero milliseconds.
     1) Initiate subscribe for ASIC-DB updates.
-    2) Read APPL-DB & ASIC-DB 
+    2) Read APPL-DB & ASIC-DB
     3) Get the diff.
-    4) If any diff, 
+    4) If any diff,
         4.1) Collect subscribe messages for a second
-        4.2) check diff against the subscribe messages 
+        4.2) check diff against the subscribe messages
     5) Rule out local interfaces & default routes
     6) If still outstanding diffs, report failure.
 
@@ -29,7 +29,7 @@ To verify:
         down to ensure failure.
         Analyze the reported failures to match expected.
     You may use the exit code to verify the result as success or not.
-    
+
 
 
 """
@@ -45,6 +45,7 @@ import syslog
 import time
 import signal
 import traceback
+import subprocess
 
 from swsscommon import swsscommon
 from utilities_common import chassis
@@ -293,7 +294,7 @@ def get_routes():
 
 def get_route_entries():
     """
-    helper to read present route entries from ASIC-DB and 
+    helper to read present route entries from ASIC-DB and
     as well initiate selector for ASIC-DB:ASIC-state updates.
     :return (selector,  subscriber, <list of sorted routes>)
     """
@@ -309,12 +310,31 @@ def get_route_entries():
         res, e = checkout_rt_entry(k)
         if res:
             rt.append(e)
-                                
+
     print_message(syslog.LOG_DEBUG, json.dumps({"ASIC_ROUTE_ENTRY": sorted(rt)}, indent=4))
 
     selector = swsscommon.Select()
     selector.addSelectable(subs)
     return (selector, subs, sorted(rt))
+
+
+def is_suppress_pending_fib_enabled():
+    cfg_db = swsscommon.ConfigDBConnector()
+    cfg_db.connect()
+
+    state = cfg_db.get_entry('DEVICE_METADATA', 'localhost').get('suppress-pending-fib')
+
+    return state == 'enabled'
+
+
+def get_frr_routes():
+    """
+    Read routes from zebra through CLI command
+    :return frr routes dictionary
+    """
+
+    output = subprocess.check_output('show ip route json', shell=True)
+    return json.loads(output)
 
 
 def get_interfaces():
@@ -354,7 +374,7 @@ def filter_out_local_interfaces(keys):
 
     chassis_local_intfs = chassis.get_chassis_local_interfaces()
     local_if_lst.update(set(chassis_local_intfs))
-    
+
     db = swsscommon.DBConnector(APPL_DB_NAME, 0)
     tbl = swsscommon.Table(db, 'ROUTE_TABLE')
 
@@ -489,11 +509,61 @@ def filter_out_standalone_tunnel_routes(routes):
     return updated_routes
 
 
+def check_frr_pending_routes():
+    """
+    TODO: add docstring
+    """
+
+    missed_rt = []
+
+    retries = 3
+    for i in range(retries):
+        missed_rt = []
+        frr_routes = get_frr_routes()
+
+        for _, entries in frr_routes.items():
+            for entry in entries:
+                if entry['protocol'] != 'bgp':
+                    continue
+
+                if not entry.get('offloaded', False):
+                    missed_rt.append(entry)
+
+        if not missed_rt:
+            break
+
+        time.sleep(5)
+
+    return missed_rt
+
+
+def get_appl_rt_key_from_frr_entry(entry):
+    prefix = entry['prefix']
+    vrf = entry['vrfName']
+
+    if vrf == 'default':
+        return prefix
+
+    return prefix + ':' + vrf
+
+
+def mitigate_installed_not_offloaded_frr_routes(missed_frr_rt):
+    db = swsscommon.DBConnector('APPL_STATE_DB', 0)
+    response_producer = swsscommon.NotificationProducer(db, f'{APPL_DB_NAME}_{swsscommon.APP_ROUTE_TABLE_NAME}_RESPONSE_CHANNEL')
+    for entry in missed_frr_rt:
+        key = get_appl_rt_key_from_frr_entry(entry)
+
+        fvs = swsscommon.FieldValuePairs([('err_str', 'SWSS_RC_SUCCESS'), ('protocol', entry['protocol'])])
+        response_producer.send('SWSS_RC_SUCCESS', key, fvs)
+
+        print_message(syslog.LOG_ERR, f'Mitigated route {key}')
+
+
 def check_routes():
     """
     The heart of this script which runs the checks.
     Read APPL-DB & ASIC-DB, the relevant tables for route checking.
-    Checkout routes in ASIC-DB to match APPL-DB, discounting local & 
+    Checkout routes in ASIC-DB to match APPL-DB, discounting local &
     default routes. In case of missed / unexpected entries in ASIC,
     it might be due to update latency between APPL & ASIC DBs. So collect
     ASIC-DB subscribe updates for a second, and checkout if you see SET
@@ -508,6 +578,7 @@ def check_routes():
     intf_appl_miss = []
     rt_appl_miss = []
     rt_asic_miss = []
+    rt_frr_miss = []
 
     results = {}
     adds = []
@@ -555,11 +626,24 @@ def check_routes():
     if rt_asic_miss:
         results["Unaccounted_ROUTE_ENTRY_TABLE_entries"] = rt_asic_miss
 
+    rt_frr_miss = []
+
+    if is_suppress_pending_fib_enabled():
+        rt_frr_miss = check_frr_pending_routes()
+
+        if rt_frr_miss:
+            results["missed_FRR_routes"] = rt_frr_miss
+
     if results:
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
         print_message(syslog.LOG_WARNING, "add: ", json.dumps(adds, indent=4))
         print_message(syslog.LOG_WARNING, "del: ", json.dumps(deletes, indent=4))
+
+        if rt_frr_miss and not rt_appl_miss and not rt_asic_miss:
+            print_message(syslog.LOG_ERR, "Some routes are not set offloaded in FRR but all routes in APPL_DB and ASIC_DB are in sync. Mitigating problem")
+            mitigate_installed_not_offloaded_frr_routes(rt_frr_miss)
+
         return -1, results
     else:
         print_message(syslog.LOG_INFO, "All good!")
@@ -605,7 +689,7 @@ def main():
                 return ret, res
         else:
             return ret, res
-            
+
 
 
 if __name__ == "__main__":

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -832,7 +832,8 @@
         "platform": "x86_64-mlnx_msn3800-r0",
         "peer_switch": "sonic-switch",
         "type": "ToRRouter",
-        "subtype": "DualToR"
+        "subtype": "DualToR",
+        "suppress-pending-fib": "enabled"
     },
     "SNMP_COMMUNITY|msft": {
         "TYPE": "RO"


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I implemented a route_check functioality that will check "show ip route json" output from FRR and will ensure that all routes are marked as offloaded. If some routes are not offloaded for 15 sec, this is considered as an issue and a mitigation logic is invoked.

#### How I did it

Modified route_check script.

#### How to verify it

- UT.
- Run on the switch, stop orchagent, announce some routes and run route_check

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

