### PR TITLE
[fast-reboot] increase docker exec check command timeout to 5 sec.

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -370,7 +370,7 @@ function check_docker_exec()
 {
     containers="radv bgp lldp swss database teamd syncd"
     for container in $containers; do
-        STATE=$(timeout 1s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
+        STATE=$(timeout 5s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
         if [[ x"${STATE}" == x"timed out" ]]; then
             error "Docker exec on $container timedout"
             exit "${EXIT_FAILURE}"


### PR DESCRIPTION
The fast-reboot test runs a lot of traffic which on our hardware simulation platform uses a lot of VM CPU and makes this command fail with timeout:

```
admin@r-panther-simx-23:~$ time docker exec -it radv echo success
success

real    0m1.201s
user    0m0.032s
sys     0m0.209s
```

Since, all other commands use 5 sec timeout I adjusted these commands timeout also to 5 sec.

This issue does not happen on any real hardware platform, however we can't guarantee dockerd won't be busy with other tasks, so the command can take more than 1 sec. To make it more robust I increased the timeout to 5 sec as in other places.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

