### PR TITLE
[sonic-package-manager] fix CLI plugin compatibility issue

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -171,7 +171,11 @@ def get_cli_plugin_path(package: Package, index: int, command: str) -> str:
         Path generated for this package.
     """
 
-    plugin_module_file = f'{package.name}_{index}.py'
+    if index == 0:
+        plugin_module_file = f'{package.name}.py'
+    else:
+        plugin_module_file = f'{package.name}_{index}.py'
+
     return os.path.join(get_cli_plugin_directory(command), plugin_module_file)
 
 

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -165,7 +165,7 @@ def test_installation_cli_plugin(package_manager, fake_metadata_resolver, anythi
     with patch('sonic_package_manager.manager.get_cli_plugin_directory') as get_dir_mock:
         get_dir_mock.return_value = '/'
         package_manager.install('test-package')
-        package_manager.docker.extract.assert_called_once_with(anything, '/cli/plugin.py', '/test-package_0.py')
+        package_manager.docker.extract.assert_called_once_with(anything, '/cli/plugin.py', '/test-package.py')
 
 
 def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolver, mock_feature_registry, anything):
@@ -178,7 +178,7 @@ def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolve
         package_manager.install('test-package')
         package_manager.docker.extract.assert_has_calls(
             [
-                call(anything, '/cli/plugin.py', '/test-package_0.py'),
+                call(anything, '/cli/plugin.py', '/test-package.py'),
                 call(anything, '/cli/plugin2.py', '/test-package_1.py'),
             ],
             any_order=True,
@@ -188,7 +188,7 @@ def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolve
         package_manager.uninstall('test-package', force=True)
         remove_mock.assert_has_calls(
             [
-                call('/test-package_0.py'),
+                call('/test-package.py'),
                 call('/test-package_1.py'),
             ],
             any_order=True,


### PR DESCRIPTION
DHCP relay extension expects the spm to name its plugin "dhcp-relay". This change keeps that format if there is just one CLI plugin.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

