### PR TITLE
[sonic-package-manager] Fix YANG validation failure on upgrade when feature has constraints in YANG model on FEATURE table

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -44,7 +44,10 @@ from sonic_package_manager.progress import ProgressManager
 from sonic_package_manager.reference import PackageReference
 from sonic_package_manager.registry import RegistryResolver
 from sonic_package_manager.service_creator import SONIC_CLI_COMMANDS
-from sonic_package_manager.service_creator.creator import ServiceCreator
+from sonic_package_manager.service_creator.creator import (
+    ServiceCreator,
+    run_command
+)
 from sonic_package_manager.service_creator.feature import FeatureRegistry
 from sonic_package_manager.service_creator.sonic_db import (
     INIT_CFG_JSON,
@@ -483,7 +486,7 @@ class PackageManager:
         # After all checks are passed we proceed to actual uninstallation
 
         try:
-            self._stop_feature(package)
+            self._disable_feature(package)
             self._uninstall_cli_plugins(package)
             self.service_creator.remove(package, keep_config=keep_config)
             self.service_creator.generate_shutdown_sequence_files(
@@ -929,7 +932,29 @@ class PackageManager:
         packages.pop(package.name)
         return packages
 
-    def _start_feature(self, package: Package, block: bool = True):
+    def _stop_feature(self, package: Package):
+        self._systemctl_action(package, 'stop')
+
+    def _start_feature(self, package: Package):
+        self._systemctl_action(package, 'start')
+
+    def _systemctl_action(self, package: Package, action: str):
+        """ Execute systemctl action for a service. """
+
+        name = package.manifest['service']['name']
+        log.info('Execute systemctl action {} on {} service'.format(action, name))
+
+        host_service = package.manifest['service']['host-service']
+        asic_service = package.manifest['service']['asic-service']
+        single_instance = host_service or (asic_service and not self.is_multi_npu)
+        multi_instance = asic_service and self.is_multi_npu
+        if single_instance:
+            run_command(['systemctl', action, name])
+        if multi_instance:
+            for npu in range(self.num_npus):
+                run_command(['systemctl', action, f'{name}@{npu}'])
+
+    def _enable_feature(self, package: Package, block: bool = True):
         """ Starts the feature and blocks till operation is finished if
         block argument is set to True.
 
@@ -940,7 +965,7 @@ class PackageManager:
 
         self._set_feature_state(package, 'enabled', block)
 
-    def _stop_feature(self, package: Package, block: bool = True):
+    def _disable_feature(self, package: Package, block: bool = True):
         """ Stops the feature and blocks till operation is finished if
         block argument is set to True.
 

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -9,6 +9,11 @@ import sonic_package_manager
 from sonic_package_manager.errors import *
 from sonic_package_manager.version import Version
 
+@pytest.fixture(autouse=True)
+def mock_run_command():
+    with patch('sonic_package_manager.manager.run_command') as run_command:
+        yield run_command
+
 
 def test_installation_not_installed(package_manager):
     package_manager.install('test-package')


### PR DESCRIPTION
In case feature's YANG model has a constraint on FEATURE table:

```
must "current() = \"disabled\" or /feature:sonic-feature/feature:FEATURE/feature:FEATURE_LIST[feature:name=\"Y\"]/feature:state = \"enabled\"" {
    error-message "X can only be set when is Y enabled";
}
```

it will fail to upgrade due to transient disablement of the feature by the upgrade process.

The upgrade process looks like this:
1. Disable feature via FEATURE table and wait for container to go down.
2. Remove all configuration files generated for this feature.
3. Create new configuration files for new docker image.
4. Merge new init_cfg from the new docker image and perform YANG validation.
5. Enable feature via FEATURE table.
6. Remove old docker image.

Since there is a transient enable/disable of the feature and YANG validation in the middle having the above constrains in YANG model would lead to an upgrade failure.

I attempt to fix this by letting the ServiceCreator know we undergo a transient disablement of the feature.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I fixed an issue that leads to upgrade failure for some extensions.

#### How I did it

Replaces setting FEATURE state with systemctl commands.

#### How to verify it

Given the above example, verify that the upgrade process passes successfully.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

