### PR TITLE
[sonic-installer] print output from "sonic-package-manager migrate"

### DIFF
--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -41,16 +41,20 @@ def run_command(command, stdout=subprocess.PIPE, env=None, shell=False):
         sys.exit(proc.returncode)
 
 # Run bash command and return output, raise if it fails
-def run_command_or_raise(argv, raise_exception=True):
+def run_command_or_raise(argv, raise_exception=True, nocapture=False):
     click.echo(click.style("Command: ", fg='cyan') + click.style(' '.join(argv), fg='green'))
 
-    proc = subprocess.Popen(argv, text=True, stdout=subprocess.PIPE)
+    stdout = None if nocapture else subprocess.PIPE
+    proc = subprocess.Popen(argv, text=True, stdout=stdout)
     out, _ = proc.communicate()
 
     if proc.returncode != 0 and raise_exception:
         raise SonicRuntimeException("Failed to run command '{0}'".format(argv))
 
-    return out.rstrip("\n")
+    if out is not None:
+        out = out.rstrip("\n")
+
+    return out
 
 # Needed to prevent "broken pipe" error messages when piping
 # output of multiple commands using subprocess.Popen()

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -384,7 +384,7 @@ def migrate_sonic_packages(bootloader, binary_image_version):
             run_command_or_raise(["chroot", new_image_mount, SONIC_PACKAGE_MANAGER, "migrate",
                                 os.path.join("/", TMP_DIR, packages_file),
                                 "--dockerd-socket", os.path.join("/", TMP_DIR, DOCKERD_SOCK),
-                                "-y"])
+                                "-y"], nocapture=True)
         finally:
             if docker_started:
                 run_command_or_raise(["chroot", new_image_mount, DOCKER_CTL_SCRIPT, "stop"], raise_exception=False)

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -91,7 +91,7 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
         call(["cp", f"{mounted_image_folder}/etc/resolv.conf", "/tmp/resolv.conf.backup"]),
         call(["cp", "/etc/resolv.conf", f"{mounted_image_folder}/etc/resolv.conf"]),
         call(["chroot", mounted_image_folder, "sh", "-c", "command -v sonic-package-manager"]),
-        call(["chroot", mounted_image_folder, "sonic-package-manager", "migrate", "/tmp/packages.json", "--dockerd-socket", "/tmp/docker.sock", "-y"]),
+        call(["chroot", mounted_image_folder, "sonic-package-manager", "migrate", "/tmp/packages.json", "--dockerd-socket", "/tmp/docker.sock", "-y"], nocapture=True),
         call(["chroot", mounted_image_folder, "/usr/lib/docker/docker.sh", "stop"], raise_exception=False),
         call(["cp", "/tmp/resolv.conf.backup", f"{mounted_image_folder}/etc/resolv.conf"], raise_exception=False),
         call(["umount", "-f", "-R", mounted_image_folder], raise_exception=False),


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Don't capture output from migrate command for better debugging.

#### How I did it

Added ```nocapture``` flag to ```run_command_or_raise```. Pass ```nocapture``` when running ```spm migrate```.

#### How to verify it

Run sonic to sonic upgrade and observe the output of migrate command.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

