### PR TITLE
[fast-reboot-filter-routes.py] Remove click and improve error reporting

### DIFF
--- a/scripts/fast-reboot-filter-routes.py
+++ b/scripts/fast-reboot-filter-routes.py
@@ -6,7 +6,6 @@ import os
 import utilities_common.cli as clicommon
 import syslog
 import traceback
-import click
 from swsscommon.swsscommon import ConfigDBConnector
 
 ROUTE_IDX = 1
@@ -14,19 +13,14 @@ ROUTE_IDX = 1
 def get_connected_routes():
     cmd = ['sudo', 'vtysh', '-c', "show ip route connected json"]
     connected_routes = []
-    try:
-        output, ret = clicommon.run_command(cmd, return_cmd=True)
-        if ret != 0:
-            click.echo(output.rstrip('\n'))
-            sys.exit(ret)
-        if output is not None:
-            route_info = json.loads(output)
-            for route in route_info.keys():
-                connected_routes.append(route)
-    except Exception:
-        ctx = click.get_current_context()
-        ctx.fail("Unable to get connected routes from bgp")
-    
+    output, ret = clicommon.run_command(cmd, return_cmd=True)
+    if ret != 0:
+        raise Exception("Failed to execute {}: {}".format(" ".join(cmd), output.rstrip('\n')))
+    if output is not None:
+        route_info = json.loads(output)
+        for route in route_info.keys():
+            connected_routes.append(route)
+
     return connected_routes
 
 def get_route(db, route):
@@ -81,7 +75,8 @@ if __name__ == '__main__':
         syslog.syslog(syslog.LOG_NOTICE, "SIGINT received. Quitting")
         res = 1
     except Exception as e:
-        syslog.syslog(syslog.LOG_ERR, "Got an exception %s: Traceback: %s" % (str(e), traceback.format_exc()))
+        print(e)
+        syslog.syslog(syslog.LOG_ERR, "Got an exception: {}: Traceback: {}".format(e, traceback.format_exc()))
         res = 2
     finally:
         syslog.closelog()


### PR DESCRIPTION
1. Removed click usage from a script since there is no active click context therefore we saw these error messages:

```
ERR fast-reboot-filter-routes: Got an exception There is no active click context.: Traceback: Traceback (most recent call last):#012  File "/usr/local/bin/fast-reboot-filter-routes.py", line 18, in get_connected_routes#012    output, ret = clicommon.run_command(cmd, return_cmd=True)#012  File "/usr/local/lib/python3.9/dist-packages/utilities_common/cli.py", line 545, in run_command#012    proc = subprocess.Popen(command, shell=shell, text=True, stdout=subprocess.PIPE)#012  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__#012    self._execute_child(args, executable, preexec_fn, close_fds,#012  File "/usr/lib/python3.9/subprocess.py", line 1823, in _execute_child#012    raise child_exception_type(errno_num, err_msg, err_filename)#012FileNotFoundError: [Errno 2] No such file or directory: 'sudo vtysh -c "show ip route connected json"'#012#012During handling of the above exception, another exception occurred:#012#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/click/globals.py", line 23, in get_current_context#012    return getattr(_local, 'stack')[-1]#012AttributeError: '_thread._local' object has no attribute 'stack'#012#012During handling of the above exception, another exception occurred:#012#012Traceback (most recent call last):#012  File "/usr/local/bin/fast-reboot-filter-routes.py", line 79, in <module>#012    res = main()#012  File "/usr/local/bin/fast-reboot-filter-routes.py", line 70, in main#012    connected_routes = get_connected_routes()#012  File "/usr/local/bin/fast-reboot-filter-routes.py", line 27, in get_connected_routes#012    ctx = click.get_current_context()#012  File "/usr/local/lib/python3.9/dist-packages/click/globals.py", line 26, in get_current_context#012    raise RuntimeError('There is no active click context.')#012RuntimeError: There is no active click context.
```

2. Improved error reporting so that when an error occurs when we run a command it will report it via terminal and syslog:

stdout:
```
Failed to execute sudo vtysh -c show ip route connected jsson: % Unknown command: show ip route connected jsson
```

syslog:
```
Oct 17 11:53:10.620788 arc-switch1025 ERR fast-reboot-filter-routes: Got an exception: Failed to execute sudo vtysh -c show ip route connected jsson: % Unknown command: show ip route connected jsson: Traceback: Traceback (most recent call last):#012  File "/home/admin/fast-reboot-filter-routes.py", line 73, in <module>#012    res = main()#012  File "/home/admin/fast-reboot-filter-routes.py", line 64, in main#012    connected_routes = get_connected_routes()#012  File "/home/admin/fast-reboot-filter-routes.py", line 18, in get_connected_routes#012    raise Exception("Failed to execute {}: {}".format(" ".join(cmd), output.rstrip('\n')))#012Exception: Failed to execute sudo vtysh -c show ip route connected jsson: % Unknown command: show ip route connected jsson
```

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

