### PR TITLE
[route_check.py] account static routes in route_check.py

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -560,7 +560,7 @@ def check_frr_pending_routes(namespace):
 
         for _, entries in frr_routes.items():
             for entry in entries:
-                if entry['protocol'] != 'bgp':
+                if entry['protocol'] in ('connected', 'kernel'):
                     continue
 
                 # TODO: Also handle VRF routes. Currently this script does not check for VRF routes so it would be incorrect for us

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -552,7 +552,7 @@ TEST_DATA = {
         RESULT: {
             DEFAULTNS: {
                 "missed_FRR_routes": [
-                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp"}
+                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp"},
                     {"prefix": "1.1.1.0/24", "vrfName": "default", "protocol": "static"},
                 ],
             },

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -535,6 +535,13 @@ TEST_DATA = {
                         "protocol": "bgp",
                     },
                 ],
+                "1.1.1.0/24": [
+                    {
+                        "prefix": "1.1.1.0/24",
+                        "vrfName": "default",
+                        "protocol": "static",
+                    },
+                ],
                 "10.10.196.24/31": [
                     {
                         "protocol": "connected",
@@ -546,6 +553,7 @@ TEST_DATA = {
             DEFAULTNS: {
                 "missed_FRR_routes": [
                     {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp"}
+                    {"prefix": "1.1.1.0/24", "vrfName": "default", "protocol": "static"},
                 ],
             },
         },


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Account for static routes in route_check.py when checking route offload status.

#### How I did it

skip routes that are "connected" or "kernel".

#### How to verify it

Run on 202311, make sure it reports Loopback IPv6 address as missing.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

