### PR TITLE
[202311][warm/fast-reboot] Retain TRANSCEIVER_INFO/STATUS tables on deinit

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -252,6 +252,8 @@ function backup_database()
                                           and not string.match(k, 'MIRROR_SESSION_TABLE|') \
                                           and not string.match(k, 'FG_ROUTE_TABLE|') \
                                           and not string.match(k, 'WARM_RESTART_ENABLE_TABLE|') \
+                                          and not string.match(k, 'TRANSCEIVER_INFO|') \
+                                          and not string.match(k, 'TRANSCEIVER_STATUS|') \
                                           and not string.match(k, 'VXLAN_TUNNEL_TABLE|') \
                                           and not string.match(k, 'BUFFER_MAX_PARAM_TABLE|') \
                                           and not string.match(k, 'FAST_RESTART_ENABLE_TABLE|') then


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Save TRANSCEIVER_INFO/STATUS tables on warm/fast-reboot.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The information in TRANSCEIVER_INFO/STATUS tables is required for orchagent to set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE=true on system startup.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Run fast/warm-reboot.

#### Additional Information (Optional)
