### PR TITLE
[qos reload] Fix "config qos reload" overriding entire CONFIG_DB

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3116,7 +3116,7 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose)
 
     _, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
     sonic_version_file = device_info.get_sonic_version_file()
-    from_db = ['-d', '--write-to-db']
+    from_db = ['-d']
     if dry_run:
         from_db = ['--additional-data'] + [str(json_data)] if json_data else []
 
@@ -3162,11 +3162,23 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose)
             )
             if os.path.isfile(qos_template_file):
                 cmd_ns = [] if ns is DEFAULT_NAMESPACE else ['-n', str(ns)]
-                fname = "{}{}".format(dry_run, asic_id_suffix) if dry_run else "config-db"
-                command = [SONIC_CFGGEN_PATH] + cmd_ns + from_db + ['-t', '{},{}'.format(buffer_template_file, fname), '-t', '{},{}'.format(qos_template_file, fname), '-y', sonic_version_file]
-                # Apply the configurations only when both buffer and qos
-                # configuration files are present
+                buffer_fname = "/tmp/cfg_buffer{}.json".format(asic_id_suffix)
+                qos_fname = "/tmp/cfg_qos{}.json".format(asic_id_suffix)
+
+                command = [SONIC_CFGGEN_PATH] + cmd_ns + from_db + ['-t', '{},{}'.format(buffer_template_file, buffer_fname), '-t', '{},{}'.format(qos_template_file, qos_fname), '-y', sonic_version_file]
                 clicommon.run_command(command, display_cmd=True)
+
+                command = [SONIC_CFGGEN_PATH] + cmd_ns + ["-j", buffer_fname, "-j", qos_fname]
+                if dry_run:
+                    out, rc = clicommon.run_command(command + ["--print-data"], display_cmd=True, return_cmd=True)
+                    if rc != 0:
+                        # clicommon.run_command does this by default when rc != 0 and return_cmd=False
+                        sys.exit(rc);
+                    with open("{}{}".format(dry_run, asic_id_suffix), 'w') as f:
+                        json.dump(json.loads(out), f, sort_keys=True, indent=4)
+                else:
+                    clicommon.run_command(command + ["--write-to-db"], display_cmd=True)
+
             else:
                 click.secho("QoS definition template not found at {}".format(
                     qos_template_file

--- a/tests/qos_config_input/0/config_qos.json
+++ b/tests/qos_config_input/0/config_qos.json
@@ -1,14 +1,528 @@
 {
-    "TC_TO_PRIORITY_GROUP_MAP": {
+    "BUFFER_PG": {
+        "Ethernet0|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet100|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet104|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet108|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet112|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet116|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet120|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet124|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet12|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet16|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet20|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet24|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet28|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet32|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet36|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet40|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet44|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet48|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet4|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet52|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet56|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet60|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet64|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet68|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet72|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet76|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet80|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet84|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet88|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet8|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet92|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet96|0": {
+            "profile": "ingress_lossy_profile"
+        }
+    },
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "mode": "static",
+            "size": "12766208",
+            "type": "egress"
+        },
+        "egress_lossy_pool": {
+            "mode": "dynamic",
+            "size": "7326924",
+            "type": "egress"
+        },
+        "ingress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "12766208",
+            "type": "ingress"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "12766208"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "egress_lossy_pool",
+            "size": "1518"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        }
+    },
+    "BUFFER_QUEUE": {
+        "Ethernet0|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet0|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet0|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet100|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet100|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet100|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet104|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet104|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet104|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet108|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet108|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet108|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet112|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet112|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet112|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet116|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet116|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet116|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet120|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet120|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet120|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet124|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet124|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet124|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet12|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet12|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet12|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet16|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet16|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet16|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet20|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet20|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet20|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet24|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet24|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet24|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet28|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet28|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet28|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet32|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet32|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet32|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet36|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet36|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet36|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet40|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet40|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet40|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet44|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet44|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet44|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet48|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet48|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet48|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet4|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet4|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet4|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet52|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet52|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet52|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet56|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet56|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet56|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet60|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet60|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet60|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet64|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet64|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet64|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet68|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet68|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet68|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet72|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet72|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet72|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet76|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet76|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet76|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet80|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet80|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet80|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet84|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet84|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet84|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet88|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet88|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet88|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet8|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet8|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet8|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet92|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet92|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet92|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet96|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet96|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet96|5-6": {
+            "profile": "egress_lossy_profile"
+        }
+    },
+    "CABLE_LENGTH": {
         "AZURE": {
-            "0": "0",
-            "1": "0",
-            "2": "0",
+            "Ethernet0": "300m",
+            "Ethernet100": "300m",
+            "Ethernet104": "300m",
+            "Ethernet108": "300m",
+            "Ethernet112": "300m",
+            "Ethernet116": "300m",
+            "Ethernet12": "300m",
+            "Ethernet120": "300m",
+            "Ethernet124": "300m",
+            "Ethernet16": "300m",
+            "Ethernet20": "300m",
+            "Ethernet24": "300m",
+            "Ethernet28": "300m",
+            "Ethernet32": "300m",
+            "Ethernet36": "300m",
+            "Ethernet4": "300m",
+            "Ethernet40": "300m",
+            "Ethernet44": "300m",
+            "Ethernet48": "300m",
+            "Ethernet52": "300m",
+            "Ethernet56": "300m",
+            "Ethernet60": "300m",
+            "Ethernet64": "300m",
+            "Ethernet68": "300m",
+            "Ethernet72": "300m",
+            "Ethernet76": "300m",
+            "Ethernet8": "300m",
+            "Ethernet80": "300m",
+            "Ethernet84": "300m",
+            "Ethernet88": "300m",
+            "Ethernet92": "300m",
+            "Ethernet96": "300m"
+        }
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0": "1",
+            "1": "1",
+            "10": "1",
+            "11": "1",
+            "12": "1",
+            "13": "1",
+            "14": "1",
+            "15": "1",
+            "16": "1",
+            "17": "1",
+            "18": "1",
+            "19": "1",
+            "2": "1",
+            "20": "1",
+            "21": "1",
+            "22": "1",
+            "23": "1",
+            "24": "1",
+            "25": "1",
+            "26": "1",
+            "27": "1",
+            "28": "1",
+            "29": "1",
             "3": "3",
+            "30": "1",
+            "31": "1",
+            "32": "1",
+            "33": "1",
+            "34": "1",
+            "35": "1",
+            "36": "1",
+            "37": "1",
+            "38": "1",
+            "39": "1",
             "4": "4",
-            "5": "0",
-            "6": "0",
-            "7": "7"
+            "40": "1",
+            "41": "1",
+            "42": "1",
+            "43": "1",
+            "44": "1",
+            "45": "1",
+            "46": "5",
+            "47": "1",
+            "48": "6",
+            "49": "1",
+            "5": "2",
+            "50": "1",
+            "51": "1",
+            "52": "1",
+            "53": "1",
+            "54": "1",
+            "55": "1",
+            "56": "1",
+            "57": "1",
+            "58": "1",
+            "59": "1",
+            "6": "1",
+            "60": "1",
+            "61": "1",
+            "62": "1",
+            "63": "1",
+            "7": "1",
+            "8": "0",
+            "9": "1"
         }
     },
     "MAP_PFC_PRIORITY_TO_QUEUE": {
@@ -20,6 +534,30 @@
             "4": "4",
             "5": "5",
             "6": "6",
+            "7": "7"
+        }
+    },
+    "PORT_QOS_MAP": {},
+    "QUEUE": {},
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "3",
+            "4": "4",
+            "5": "0",
+            "6": "0",
             "7": "7"
         }
     },
@@ -35,103 +573,21 @@
             "7": "7"
         }
     },
-    "DSCP_TO_TC_MAP": {
-        "AZURE": {
-            "0" : "1",
-            "1" : "1",
-            "2" : "1",
-            "3" : "3",
-            "4" : "4",
-            "5" : "2",
-            "6" : "1",
-            "7" : "1",
-            "8" : "0",
-            "9" : "1",
-            "10": "1",
-            "11": "1",
-            "12": "1",
-            "13": "1",
-            "14": "1",
-            "15": "1",
-            "16": "1",
-            "17": "1",
-            "18": "1",
-            "19": "1",
-            "20": "1",
-            "21": "1",
-            "22": "1",
-            "23": "1",
-            "24": "1",
-            "25": "1",
-            "26": "1",
-            "27": "1",
-            "28": "1",
-            "29": "1",
-            "30": "1",
-            "31": "1",
-            "32": "1",
-            "33": "1",
-            "34": "1",
-            "35": "1",
-            "36": "1",
-            "37": "1",
-            "38": "1",
-            "39": "1",
-            "40": "1",
-            "41": "1",
-            "42": "1",
-            "43": "1",
-            "44": "1",
-            "45": "1",
-            "46": "5",
-            "47": "1",
-            "48": "6",
-            "49": "1",
-            "50": "1",
-            "51": "1",
-            "52": "1",
-            "53": "1",
-            "54": "1",
-            "55": "1",
-            "56": "1",
-            "57": "1",
-            "58": "1",
-            "59": "1",
-            "60": "1",
-            "61": "1",
-            "62": "1",
-            "63": "1"
-        }
-    },
-    "SCHEDULER": {
-        "scheduler.0": {
-            "type"  : "DWRR",
-            "weight": "14"
-        },
-        "scheduler.1": {
-            "type"  : "DWRR",
-            "weight": "15"
-        }
-    },
-    "PORT_QOS_MAP": {
-    },
     "WRED_PROFILE": {
-        "AZURE_LOSSLESS" : {
-            "wred_green_enable"      : "true",
-            "wred_yellow_enable"     : "true",
-            "wred_red_enable"        : "true",
-            "ecn"                    : "ecn_all",
-            "green_max_threshold"    : "2097152",
-            "green_min_threshold"    : "1048576",
-            "yellow_max_threshold"   : "2097152",
-            "yellow_min_threshold"   : "1048576",
-            "red_max_threshold"      : "2097152",
-            "red_min_threshold"      : "1048576",
-            "green_drop_probability" : "5",
+        "AZURE_LOSSLESS": {
+            "ecn": "ecn_all",
+            "green_drop_probability": "5",
+            "green_max_threshold": "2097152",
+            "green_min_threshold": "1048576",
+            "red_drop_probability": "5",
+            "red_max_threshold": "2097152",
+            "red_min_threshold": "1048576",
+            "wred_green_enable": "true",
+            "wred_red_enable": "true",
+            "wred_yellow_enable": "true",
             "yellow_drop_probability": "5",
-            "red_drop_probability"   : "5"
+            "yellow_max_threshold": "2097152",
+            "yellow_min_threshold": "1048576"
         }
-    },
-    "QUEUE": {
     }
 }

--- a/tests/qos_config_input/1/config_qos.json
+++ b/tests/qos_config_input/1/config_qos.json
@@ -1,14 +1,528 @@
 {
-    "TC_TO_PRIORITY_GROUP_MAP": {
+    "BUFFER_PG": {
+        "Ethernet0|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet100|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet104|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet108|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet112|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet116|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet120|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet124|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet12|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet16|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet20|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet24|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet28|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet32|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet36|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet40|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet44|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet48|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet4|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet52|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet56|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet60|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet64|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet68|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet72|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet76|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet80|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet84|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet88|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet8|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet92|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet96|0": {
+            "profile": "ingress_lossy_profile"
+        }
+    },
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "mode": "static",
+            "size": "12766208",
+            "type": "egress"
+        },
+        "egress_lossy_pool": {
+            "mode": "dynamic",
+            "size": "7326924",
+            "type": "egress"
+        },
+        "ingress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "12766208",
+            "type": "ingress"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "12766208"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "egress_lossy_pool",
+            "size": "1518"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        }
+    },
+    "BUFFER_QUEUE": {
+        "Ethernet0|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet0|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet0|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet100|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet100|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet100|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet104|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet104|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet104|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet108|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet108|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet108|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet112|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet112|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet112|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet116|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet116|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet116|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet120|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet120|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet120|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet124|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet124|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet124|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet12|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet12|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet12|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet16|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet16|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet16|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet20|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet20|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet20|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet24|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet24|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet24|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet28|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet28|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet28|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet32|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet32|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet32|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet36|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet36|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet36|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet40|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet40|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet40|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet44|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet44|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet44|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet48|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet48|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet48|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet4|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet4|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet4|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet52|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet52|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet52|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet56|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet56|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet56|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet60|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet60|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet60|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet64|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet64|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet64|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet68|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet68|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet68|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet72|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet72|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet72|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet76|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet76|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet76|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet80|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet80|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet80|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet84|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet84|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet84|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet88|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet88|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet88|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet8|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet8|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet8|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet92|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet92|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet92|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet96|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet96|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet96|5-6": {
+            "profile": "egress_lossy_profile"
+        }
+    },
+    "CABLE_LENGTH": {
         "AZURE": {
-            "0": "0",
-            "1": "0",
-            "2": "0",
+            "Ethernet0": "300m",
+            "Ethernet100": "300m",
+            "Ethernet104": "300m",
+            "Ethernet108": "300m",
+            "Ethernet112": "300m",
+            "Ethernet116": "300m",
+            "Ethernet12": "300m",
+            "Ethernet120": "300m",
+            "Ethernet124": "300m",
+            "Ethernet16": "300m",
+            "Ethernet20": "300m",
+            "Ethernet24": "300m",
+            "Ethernet28": "300m",
+            "Ethernet32": "300m",
+            "Ethernet36": "300m",
+            "Ethernet4": "300m",
+            "Ethernet40": "300m",
+            "Ethernet44": "300m",
+            "Ethernet48": "300m",
+            "Ethernet52": "300m",
+            "Ethernet56": "300m",
+            "Ethernet60": "300m",
+            "Ethernet64": "300m",
+            "Ethernet68": "300m",
+            "Ethernet72": "300m",
+            "Ethernet76": "300m",
+            "Ethernet8": "300m",
+            "Ethernet80": "300m",
+            "Ethernet84": "300m",
+            "Ethernet88": "300m",
+            "Ethernet92": "300m",
+            "Ethernet96": "300m"
+        }
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0": "1",
+            "1": "1",
+            "10": "1",
+            "11": "1",
+            "12": "1",
+            "13": "1",
+            "14": "1",
+            "15": "1",
+            "16": "1",
+            "17": "1",
+            "18": "1",
+            "19": "1",
+            "2": "1",
+            "20": "1",
+            "21": "1",
+            "22": "1",
+            "23": "1",
+            "24": "1",
+            "25": "1",
+            "26": "1",
+            "27": "1",
+            "28": "1",
+            "29": "1",
             "3": "3",
+            "30": "1",
+            "31": "1",
+            "32": "1",
+            "33": "1",
+            "34": "1",
+            "35": "1",
+            "36": "1",
+            "37": "1",
+            "38": "1",
+            "39": "1",
             "4": "4",
-            "5": "0",
-            "6": "0",
-            "7": "7"
+            "40": "1",
+            "41": "1",
+            "42": "1",
+            "43": "1",
+            "44": "1",
+            "45": "1",
+            "46": "5",
+            "47": "1",
+            "48": "6",
+            "49": "1",
+            "5": "2",
+            "50": "1",
+            "51": "1",
+            "52": "1",
+            "53": "1",
+            "54": "1",
+            "55": "1",
+            "56": "1",
+            "57": "1",
+            "58": "1",
+            "59": "1",
+            "6": "1",
+            "60": "1",
+            "61": "1",
+            "62": "1",
+            "63": "1",
+            "7": "1",
+            "8": "0",
+            "9": "1"
         }
     },
     "MAP_PFC_PRIORITY_TO_QUEUE": {
@@ -20,6 +534,30 @@
             "4": "4",
             "5": "5",
             "6": "6",
+            "7": "7"
+        }
+    },
+    "PORT_QOS_MAP": {},
+    "QUEUE": {},
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "3",
+            "4": "4",
+            "5": "0",
+            "6": "0",
             "7": "7"
         }
     },
@@ -35,103 +573,21 @@
             "7": "7"
         }
     },
-    "DSCP_TO_TC_MAP": {
-        "AZURE": {
-            "0" : "1",
-            "1" : "1",
-            "2" : "1",
-            "3" : "3",
-            "4" : "4",
-            "5" : "2",
-            "6" : "1",
-            "7" : "1",
-            "8" : "0",
-            "9" : "1",
-            "10": "1",
-            "11": "1",
-            "12": "1",
-            "13": "1",
-            "14": "1",
-            "15": "1",
-            "16": "1",
-            "17": "1",
-            "18": "1",
-            "19": "1",
-            "20": "1",
-            "21": "1",
-            "22": "1",
-            "23": "1",
-            "24": "1",
-            "25": "1",
-            "26": "1",
-            "27": "1",
-            "28": "1",
-            "29": "1",
-            "30": "1",
-            "31": "1",
-            "32": "1",
-            "33": "1",
-            "34": "1",
-            "35": "1",
-            "36": "1",
-            "37": "1",
-            "38": "1",
-            "39": "1",
-            "40": "1",
-            "41": "1",
-            "42": "1",
-            "43": "1",
-            "44": "1",
-            "45": "1",
-            "46": "5",
-            "47": "1",
-            "48": "6",
-            "49": "1",
-            "50": "1",
-            "51": "1",
-            "52": "1",
-            "53": "1",
-            "54": "1",
-            "55": "1",
-            "56": "1",
-            "57": "1",
-            "58": "1",
-            "59": "1",
-            "60": "1",
-            "61": "1",
-            "62": "1",
-            "63": "1"
-        }
-    },
-    "SCHEDULER": {
-        "scheduler.0": {
-            "type"  : "DWRR",
-            "weight": "14"
-        },
-        "scheduler.1": {
-            "type"  : "DWRR",
-            "weight": "15"
-        }
-    },
-    "PORT_QOS_MAP": {
-    },
     "WRED_PROFILE": {
-        "AZURE_LOSSLESS" : {
-            "wred_green_enable"      : "true",
-            "wred_yellow_enable"     : "true",
-            "wred_red_enable"        : "true",
-            "ecn"                    : "ecn_all",
-            "green_max_threshold"    : "2097152",
-            "green_min_threshold"    : "1048576",
-            "yellow_max_threshold"   : "2097152",
-            "yellow_min_threshold"   : "1048576",
-            "red_max_threshold"      : "2097152",
-            "red_min_threshold"      : "1048576",
-            "green_drop_probability" : "5",
+        "AZURE_LOSSLESS": {
+            "ecn": "ecn_all",
+            "green_drop_probability": "5",
+            "green_max_threshold": "2097152",
+            "green_min_threshold": "1048576",
+            "red_drop_probability": "5",
+            "red_max_threshold": "2097152",
+            "red_min_threshold": "1048576",
+            "wred_green_enable": "true",
+            "wred_red_enable": "true",
+            "wred_yellow_enable": "true",
             "yellow_drop_probability": "5",
-            "red_drop_probability"   : "5"
+            "yellow_max_threshold": "2097152",
+            "yellow_min_threshold": "1048576"
         }
-    },
-    "QUEUE": {
     }
 }

--- a/tests/qos_config_input/config_qos.json
+++ b/tests/qos_config_input/config_qos.json
@@ -1,14 +1,528 @@
 {
-    "TC_TO_PRIORITY_GROUP_MAP": {
+    "BUFFER_PG": {
+        "Ethernet0|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet100|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet104|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet108|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet112|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet116|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet120|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet124|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet12|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet16|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet20|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet24|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet28|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet32|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet36|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet40|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet44|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet48|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet4|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet52|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet56|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet60|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet64|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet68|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet72|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet76|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet80|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet84|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet88|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet8|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet92|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet96|0": {
+            "profile": "ingress_lossy_profile"
+        }
+    },
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "mode": "static",
+            "size": "12766208",
+            "type": "egress"
+        },
+        "egress_lossy_pool": {
+            "mode": "dynamic",
+            "size": "7326924",
+            "type": "egress"
+        },
+        "ingress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "12766208",
+            "type": "ingress"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "12766208"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "egress_lossy_pool",
+            "size": "1518"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        }
+    },
+    "BUFFER_QUEUE": {
+        "Ethernet0|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet0|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet0|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet100|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet100|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet100|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet104|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet104|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet104|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet108|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet108|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet108|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet112|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet112|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet112|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet116|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet116|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet116|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet120|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet120|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet120|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet124|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet124|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet124|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet12|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet12|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet12|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet16|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet16|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet16|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet20|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet20|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet20|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet24|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet24|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet24|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet28|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet28|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet28|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet32|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet32|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet32|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet36|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet36|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet36|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet40|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet40|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet40|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet44|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet44|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet44|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet48|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet48|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet48|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet4|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet4|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet4|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet52|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet52|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet52|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet56|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet56|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet56|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet60|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet60|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet60|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet64|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet64|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet64|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet68|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet68|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet68|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet72|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet72|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet72|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet76|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet76|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet76|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet80|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet80|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet80|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet84|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet84|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet84|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet88|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet88|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet88|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet8|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet8|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet8|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet92|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet92|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet92|5-6": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet96|0-2": {
+            "profile": "egress_lossy_profile"
+        },
+        "Ethernet96|3-4": {
+            "profile": "egress_lossless_profile"
+        },
+        "Ethernet96|5-6": {
+            "profile": "egress_lossy_profile"
+        }
+    },
+    "CABLE_LENGTH": {
         "AZURE": {
-            "0": "0",
-            "1": "0",
-            "2": "0",
+            "Ethernet0": "300m",
+            "Ethernet100": "300m",
+            "Ethernet104": "300m",
+            "Ethernet108": "300m",
+            "Ethernet112": "300m",
+            "Ethernet116": "300m",
+            "Ethernet12": "300m",
+            "Ethernet120": "300m",
+            "Ethernet124": "300m",
+            "Ethernet16": "300m",
+            "Ethernet20": "300m",
+            "Ethernet24": "300m",
+            "Ethernet28": "300m",
+            "Ethernet32": "300m",
+            "Ethernet36": "300m",
+            "Ethernet4": "300m",
+            "Ethernet40": "300m",
+            "Ethernet44": "300m",
+            "Ethernet48": "300m",
+            "Ethernet52": "300m",
+            "Ethernet56": "300m",
+            "Ethernet60": "300m",
+            "Ethernet64": "300m",
+            "Ethernet68": "300m",
+            "Ethernet72": "300m",
+            "Ethernet76": "300m",
+            "Ethernet8": "300m",
+            "Ethernet80": "300m",
+            "Ethernet84": "300m",
+            "Ethernet88": "300m",
+            "Ethernet92": "300m",
+            "Ethernet96": "300m"
+        }
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0": "1",
+            "1": "1",
+            "10": "1",
+            "11": "1",
+            "12": "1",
+            "13": "1",
+            "14": "1",
+            "15": "1",
+            "16": "1",
+            "17": "1",
+            "18": "1",
+            "19": "1",
+            "2": "1",
+            "20": "1",
+            "21": "1",
+            "22": "1",
+            "23": "1",
+            "24": "1",
+            "25": "1",
+            "26": "1",
+            "27": "1",
+            "28": "1",
+            "29": "1",
             "3": "3",
+            "30": "1",
+            "31": "1",
+            "32": "1",
+            "33": "1",
+            "34": "1",
+            "35": "1",
+            "36": "1",
+            "37": "1",
+            "38": "1",
+            "39": "1",
             "4": "4",
-            "5": "0",
-            "6": "0",
-            "7": "7"
+            "40": "1",
+            "41": "1",
+            "42": "1",
+            "43": "1",
+            "44": "1",
+            "45": "1",
+            "46": "5",
+            "47": "1",
+            "48": "6",
+            "49": "1",
+            "5": "2",
+            "50": "1",
+            "51": "1",
+            "52": "1",
+            "53": "1",
+            "54": "1",
+            "55": "1",
+            "56": "1",
+            "57": "1",
+            "58": "1",
+            "59": "1",
+            "6": "1",
+            "60": "1",
+            "61": "1",
+            "62": "1",
+            "63": "1",
+            "7": "1",
+            "8": "0",
+            "9": "1"
         }
     },
     "MAP_PFC_PRIORITY_TO_QUEUE": {
@@ -20,6 +534,42 @@
             "4": "4",
             "5": "5",
             "6": "6",
+            "7": "7"
+        }
+    },
+    "MPLS_TC_TO_TC_MAP": {
+        "AZURE": {
+            "0": "1",
+            "1": "1",
+            "2": "1",
+            "3": "3",
+            "4": "4",
+            "5": "2",
+            "6": "1",
+            "7": "1"
+        }
+    },
+    "PORT_QOS_MAP": {},
+    "QUEUE": {},
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "3",
+            "4": "4",
+            "5": "0",
+            "6": "0",
             "7": "7"
         }
     },
@@ -35,115 +585,21 @@
             "7": "7"
         }
     },
-    "DSCP_TO_TC_MAP": {
-        "AZURE": {
-            "0" : "1",
-            "1" : "1",
-            "2" : "1",
-            "3" : "3",
-            "4" : "4",
-            "5" : "2",
-            "6" : "1",
-            "7" : "1",
-            "8" : "0",
-            "9" : "1",
-            "10": "1",
-            "11": "1",
-            "12": "1",
-            "13": "1",
-            "14": "1",
-            "15": "1",
-            "16": "1",
-            "17": "1",
-            "18": "1",
-            "19": "1",
-            "20": "1",
-            "21": "1",
-            "22": "1",
-            "23": "1",
-            "24": "1",
-            "25": "1",
-            "26": "1",
-            "27": "1",
-            "28": "1",
-            "29": "1",
-            "30": "1",
-            "31": "1",
-            "32": "1",
-            "33": "1",
-            "34": "1",
-            "35": "1",
-            "36": "1",
-            "37": "1",
-            "38": "1",
-            "39": "1",
-            "40": "1",
-            "41": "1",
-            "42": "1",
-            "43": "1",
-            "44": "1",
-            "45": "1",
-            "46": "5",
-            "47": "1",
-            "48": "6",
-            "49": "1",
-            "50": "1",
-            "51": "1",
-            "52": "1",
-            "53": "1",
-            "54": "1",
-            "55": "1",
-            "56": "1",
-            "57": "1",
-            "58": "1",
-            "59": "1",
-            "60": "1",
-            "61": "1",
-            "62": "1",
-            "63": "1"
-        }
-    },
-    "MPLS_TC_TO_TC_MAP": {
-        "AZURE": {
-            "0" : "1",
-            "1" : "1",
-            "2" : "1",
-            "3" : "3",
-            "4" : "4",
-            "5" : "2",
-            "6" : "1",
-            "7" : "1"
-        }
-    },
-    "SCHEDULER": {
-        "scheduler.0": {
-            "type"  : "DWRR",
-            "weight": "14"
-        },
-        "scheduler.1": {
-            "type"  : "DWRR",
-            "weight": "15"
-        }
-    },
-    "PORT_QOS_MAP": {
-    },
     "WRED_PROFILE": {
-        "AZURE_LOSSLESS" : {
-            "wred_green_enable"      : "true",
-            "wred_yellow_enable"     : "true",
-            "wred_red_enable"        : "true",
-            "ecn"                    : "ecn_all",
-            "green_max_threshold"    : "2097152",
-            "green_min_threshold"    : "1048576",
-            "yellow_max_threshold"   : "2097152",
-            "yellow_min_threshold"   : "1048576",
-            "red_max_threshold"      : "2097152",
-            "red_min_threshold"      : "1048576",
-            "green_drop_probability" : "5",
+        "AZURE_LOSSLESS": {
+            "ecn": "ecn_all",
+            "green_drop_probability": "5",
+            "green_max_threshold": "2097152",
+            "green_min_threshold": "1048576",
+            "red_drop_probability": "5",
+            "red_max_threshold": "2097152",
+            "red_min_threshold": "1048576",
+            "wred_green_enable": "true",
+            "wred_red_enable": "true",
+            "wred_yellow_enable": "true",
             "yellow_drop_probability": "5",
-            "red_drop_probability"   : "5"
+            "yellow_max_threshold": "2097152",
+            "yellow_min_threshold": "1048576"
         }
-    },
-    "QUEUE": {
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

`config qos reload` command uses a combination of `sonic-cfggen`'s flags `-d` and `--write-to-db` that makes  it override entire CONFIG_DB, updating every key. This leads to issues with Orchs, daemons that do not support updating keys in CONFIG_DB. Best case, it causes errors in logs.

#### How I did it

First, render templates to temporary files, then load those files into CONFIG_DB.
Also, fixed an issue where using `dry_run` option only produced QOS config but not the buffer configuration and updated test files accordingly.

#### How to verify it

Run on switch:

```
root@r-bulldog-04:/home/admin# config qos reload
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-mlnx_msn2100-r0/ACS-MSN2100/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-mlnx_msn2100-r0/ACS-MSN2100/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

