### PR TITLE
[reload] stop timers on reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -977,6 +977,12 @@ def _stop_services():
     except subprocess.CalledProcessError as err:
         pass
 
+    # Get the list of dependencies for sonic.target to fetch timer units
+    for service in _get_sonic_services():
+        if service.endswith('.timer'):
+            # Stop the timer unit
+            clicommon.run_command(['sudo', 'systemctl', 'stop', service], display_cmd=True)
+
     click.echo("Stopping SONiC target ...")
     clicommon.run_command(['sudo', 'systemctl', 'stop', 'sonic.target', '--job-mode', 'replace-irreversibly'])
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -53,6 +53,7 @@ load_minigraph_platform_false_path = os.path.join(load_minigraph_input_path, "pl
 load_minigraph_command_output="""\
 Acquired lock on {0}
 Disabling container and routeCheck monitoring ...
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
 Running command: config qos reload --no-dynamic-buffer --no-delay
@@ -70,6 +71,7 @@ Failed to acquire lock on {0}
 
 load_minigraph_command_bypass_lock_output = """\
 Bypass lock on {}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
 Running command: config qos reload --no-dynamic-buffer --no-delay
@@ -81,6 +83,7 @@ Please note setting loaded from minigraph will be lost after system reboot. To p
 
 load_minigraph_platform_plugin_command_output="""\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
 Running command: config qos reload --no-dynamic-buffer --no-delay
@@ -165,6 +168,7 @@ Exit: 4. Command: kill 104 failed.
 
 RELOAD_CONFIG_DB_OUTPUT = """\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
 Restarting SONiC target ...
@@ -178,6 +182,7 @@ Failed to acquire lock on {0}
 
 RELOAD_CONFIG_DB_BYPASS_LOCK_OUTPUT = """\
 Bypass lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
 Restarting SONiC target ...
@@ -186,6 +191,7 @@ Reloading Monit configuration ...
 
 RELOAD_YANG_CFG_OUTPUT = """\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -Y /tmp/config.json --write-to-db
 Restarting SONiC target ...
@@ -195,6 +201,7 @@ Released lock on {0}
 
 RELOAD_MASIC_CONFIG_DB_OUTPUT = """\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config0.json -n asic0 --write-to-db
@@ -210,6 +217,7 @@ Running command: /usr/local/bin/sonic-cfggen -H -k Seastone-DX010-25-50 --write-
 
 reload_config_with_disabled_service_output="""\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
 Restarting SONiC target ...
@@ -219,6 +227,7 @@ Released lock on {0}
 
 reload_config_masic_onefile_output = """\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Restarting SONiC target ...
 Reloading Monit configuration ...
@@ -227,6 +236,7 @@ Released lock on {0}
 
 reload_config_masic_onefile_gen_sysinfo_output = """\
 Acquired lock on {0}
+Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -k Mellanox-SN3800-D112C8 --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -H -k multi_asic -n asic0 --write-to-db
@@ -307,7 +317,7 @@ def mock_run_command_side_effect(*args, **kwargs):
         if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
-            return 'sonic.target\nswss', 0
+            return 'sonic.target\nswss\nfeatured.timer', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -1058,7 +1068,7 @@ class TestLoadMinigraph(object):
                 (load_minigraph_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 16
+            assert mock_run_command.call_count == 19
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))
@@ -1102,7 +1112,7 @@ class TestLoadMinigraph(object):
                 assert result.exit_code == 0
                 assert result.output == \
                     load_minigraph_command_bypass_lock_output.format(config.SYSTEM_RELOAD_LOCK)
-                assert mock_run_command.call_count == 12
+                assert mock_run_command.call_count == 15
             finally:
                 flock.release_flock(fd)
 
@@ -1120,7 +1130,7 @@ class TestLoadMinigraph(object):
                 (load_minigraph_platform_plugin_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 12
+            assert mock_run_command.call_count == 15
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
     def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I implemented a fix to stop timers upon reload/load_minigraph. If "config reload" or "config load_minigraph" is executed soon after system has started a timer may expire in the middle of the command causing subsequent failures.

Here's what is observed:

```
2025 Aug  6 18:29:35.532425 sonic INFO python[36429]: ansible-command Invoked with _uses_shell=True _raw_params=config load_minigraph --override_config -y warn=True stdin_add_newline=True strip_empty_ends=True argv=None chdir=None execut
able=None creates=None removes=None stdin=None
2025 Aug  6 18:29:35.754152 sonic NOTICE switch_trimming: 'load_minigraph' executing with command: config load_minigraph --override_config -y
2025 Aug  6 18:30:30.306602 sonic INFO systemd[1]: Stopped target sonic.target - SONiC services target..

2025 Aug  6 18:30:31.333507 sonic DEBUG systemd[1]: tacacs-config.timer: Timer elapsed.
2025 Aug  6 18:30:31.334003 sonic DEBUG systemd[1]: sonic.target: Installed new job sonic.target/start as 2793
2025 Aug  6 18:30:32.371292 sonic DEBUG systemd[1]: sonic.target changed dead -> active
```

#### How I did it

Stop timers associated with sonic.target

#### How to verify it

I put a breakpoint after stopping sonic.target. Soon after reboot I execute "config reload" command. I then wait for ~5-6 min, no services start. Without this fix, services would start.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

